### PR TITLE
background file updated with the correct sample name for TTbar samples

### DIFF
--- a/config/background_samples.yaml
+++ b/config/background_samples.yaml
@@ -6,13 +6,12 @@ WtoLNu_amcatnloFXFX:
 ############## TT ##############
 # TT:
 #   sampleType: TT
-TTTo2L2Nu:
+TTto2L2Nu:            #previous version was TTTo2L2Nu (this cost 3 hours for bbww and then now 3 hours of my life)
   sampleType: TT
-TTTo4Q:
+TTto4Q:
   sampleType: TT
-TTToLNu2Q:
+TTtoLNu2Q:
   sampleType: TT
-
 
 ############## DY ##############
 DYto2L_M_10to50_amcatnloFXFX:


### PR DESCRIPTION
previous version had sample names `TTTo....`, but correct one is `TTto...`
(this had previously cost 3 hours for bbWW [Devin] and then now 3 hours of my life :') )