### PR TITLE
v3 use PNet, so Jet_btagDeepFlavB -> Jet_btagPNetB

### DIFF
--- a/AnaProd/baseline.py
+++ b/AnaProd/baseline.py
@@ -252,7 +252,7 @@ def GenRecoJetMatching(df):
 def DefineHbbCand(df, met_type):
     df = df.Define(
         "Jet_HHbtag",
-        f"if(HttCandidate.channel()==Channel::eTau || HttCandidate.channel()==Channel::muTau || HttCandidate.channel()==Channel::tauTau) return GetHHBtagScore(Jet_bCand, Jet_idx, Jet_p4, Jet_btagPNetB, {met_type}_pt,  {met_type}_phi, HttCandidate, period, event); return Jet_btagPNetB;",
+        f"return GetHHBtagScore(Jet_bCand, Jet_idx, Jet_p4, Jet_btagPNetB, {met_type}_pt,  {met_type}_phi, HttCandidate, period, event); return Jet_btagPNetB;",
     )
     df = df.Define(
         "HbbCandidate", "GetHbbCandidate(Jet_HHbtag, Jet_bCand, Jet_p4, Jet_idx)"

--- a/AnaProd/baseline.py
+++ b/AnaProd/baseline.py
@@ -252,7 +252,7 @@ def GenRecoJetMatching(df):
 def DefineHbbCand(df, met_type):
     df = df.Define(
         "Jet_HHbtag",
-        f"if(HttCandidate.channel()==Channel::eTau || HttCandidate.channel()==Channel::muTau || HttCandidate.channel()==Channel::tauTau) return GetHHBtagScore(Jet_bCand, Jet_idx, Jet_p4,Jet_btagDeepFlavB, {met_type}_pt,  {met_type}_phi, HttCandidate, period, event); return Jet_btagDeepFlavB;",
+        f"if(HttCandidate.channel()==Channel::eTau || HttCandidate.channel()==Channel::muTau || HttCandidate.channel()==Channel::tauTau) return GetHHBtagScore(Jet_bCand, Jet_idx, Jet_p4, Jet_btagPNetB, {met_type}_pt,  {met_type}_phi, HttCandidate, period, event); return Jet_btagPNetB;",
     )
     df = df.Define(
         "HbbCandidate", "GetHbbCandidate(Jet_HHbtag, Jet_bCand, Jet_p4, Jet_idx)"

--- a/AnaProd/baseline.py
+++ b/AnaProd/baseline.py
@@ -252,7 +252,7 @@ def GenRecoJetMatching(df):
 def DefineHbbCand(df, met_type):
     df = df.Define(
         "Jet_HHbtag",
-        f"return GetHHBtagScore(Jet_bCand, Jet_idx, Jet_p4, Jet_btagPNetB, {met_type}_pt,  {met_type}_phi, HttCandidate, period, event); return Jet_btagPNetB;",
+        f"return GetHHBtagScore(Jet_bCand, Jet_idx, Jet_p4, Jet_btagPNetB, {met_type}_pt,  {met_type}_phi, HttCandidate, period, event);",
     )
     df = df.Define(
         "HbbCandidate", "GetHbbCandidate(Jet_HHbtag, Jet_bCand, Jet_p4, Jet_idx)"


### PR DESCRIPTION
https://github.com/elviramartinv/HHbtag/tree/CCLUB_v3.3

6. jet_btagScore: The score of the b-jet candidate given by the b-tagger: v1 & v2: DeepFlavour; v3: ParticleNet

We were previously using the `Jet_btagDeepFlavB`, so changed it to `Jet_btagPNetB` 