### PR TITLE
Category definitions for res2b, res1b, and boosted

### DIFF
--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -306,13 +306,19 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
             f"SelectedFatJet_particleNet_MD_JetTagger_boosted_vec",
             f"SelectedFatJet_particleNet_MD_JetTagger[fatJet_sel]",
         )
+        # Run 3
+        self.df = self.df.Define(
+            "SelectedFatJet_particleNet_XbbVsQCD_boosted_vec",
+            "SelectedFatJet_particleNet_XbbVsQCD[fatJet_sel];" # FatJet_particleNet_XbbVsQCD: ParticleNet X->bb vs. QCD score: Xbb/(Xbb+QCD)
+        )
         self.df = self.df.Define(
             "SelectedFatJet_idxUnordered",
             "CreateIndexes(SelectedFatJet_p4[fatJet_sel].size())",
         )
         self.df = self.df.Define(
             "SelectedFatJet_idxOrdered",
-            f"ReorderObjects(SelectedFatJet_particleNet_MD_JetTagger_boosted_vec, SelectedFatJet_idxUnordered)",
+            "ReorderObjects(SelectedFatJet_particleNet_XbbVsQCD_boosted_vec, SelectedFatJet_idxUnordered)",
+            # f"ReorderObjects(SelectedFatJet_particleNet_MD_JetTagger_boosted_vec, SelectedFatJet_idxUnordered)",
         )
 
         for fatJetVar in FatJetObservables:

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -287,7 +287,10 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         self.df = self.df.Define(
             "SelectedFatJet_particleNet_MD_JetTagger", particleNet_MD_JetTagger
         )
-        self.df = self.df.Define("fatJet_presel", f"SelectedFatJet_pt>{self.config['boosted_fatjet_presel']['pt']} && abs(SelectedFatJet_eta)<{self.config['boosted_fatjet_presel']['eta']}")
+        self.df = self.df.Define(
+            "fatJet_presel",
+            f"SelectedFatJet_pt>{self.config['boosted_fatjet_presel']['pt']} && abs(SelectedFatJet_eta)<{self.config['boosted_fatjet_presel']['eta']}",
+        )
         self.df = self.df.Define(
             "fatJet_sel",
             " RemoveOverlaps(SelectedFatJet_p4, fatJet_presel, {tau1_p4, tau2_p4}, 0.8)",
@@ -461,8 +464,10 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         )
         for category_to_def in self.config["category_definition"].keys():
             category_name = category_to_def
-            if category_name == "boosted": pNetWP = 0.75 #Run 3 AN has optimized cut at 0.75
-            else: pNetWP = self.pNetWP
+            if category_name == "boosted":
+                pNetWP = 0.75  # Run 3 AN has optimized cut at 0.75
+            else:
+                pNetWP = self.pNetWP
             self.DefineAndAppend(
                 category_to_def,
                 self.config["category_definition"][category_to_def].format(

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -287,7 +287,7 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         self.df = self.df.Define(
             "SelectedFatJet_particleNet_MD_JetTagger", particleNet_MD_JetTagger
         )
-        self.df = self.df.Define("fatJet_presel", f"SelectedFatJet_pt>250")
+        self.df = self.df.Define("fatJet_presel", f"SelectedFatJet_pt>{self.config['boosted_fatjet_presel']['pt']} && abs(SelectedFatJet_eta)<{self.config['boosted_fatjet_presel']['eta']}")
         self.df = self.df.Define(
             "fatJet_sel",
             " RemoveOverlaps(SelectedFatJet_p4, fatJet_presel, {tau1_p4, tau2_p4}, 0.8)",
@@ -461,10 +461,12 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         )
         for category_to_def in self.config["category_definition"].keys():
             category_name = category_to_def
+            if category_name == "boosted": pNetWP = 0.75 #Run 3 AN has optimized cut at 0.75
+            else: pNetWP = self.pNetWP
             self.DefineAndAppend(
                 category_to_def,
                 self.config["category_definition"][category_to_def].format(
-                    pNetWP=self.pNetWP, region=self.region
+                    pNetWP=pNetWP, region=self.region
                 ),
             )
 

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -287,10 +287,7 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         self.df = self.df.Define(
             "SelectedFatJet_particleNet_MD_JetTagger", particleNet_MD_JetTagger
         )
-        self.df = self.df.Define(
-            "fatJet_presel",
-            f"SelectedFatJet_pt>{self.config['boosted_fatjet_presel']['pt']} && abs(SelectedFatJet_eta)<{self.config['boosted_fatjet_presel']['eta']}",
-        )
+        self.df = self.df.Define("fatJet_presel", f"SelectedFatJet_pt>250")
         self.df = self.df.Define(
             "fatJet_sel",
             " RemoveOverlaps(SelectedFatJet_p4, fatJet_presel, {tau1_p4, tau2_p4}, 0.8)",

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -308,9 +308,9 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         )
         # Run 3
         self.df = self.df.Define(
-            "SelectedFatJet_particleNet_XbbVsQCD_boosted_vec",
+            f"SelectedFatJet_particleNet_XbbVsQCD_boosted_vec",
             f"SelectedFatJet_particleNet_XbbVsQCD[fatJet_sel];",
-        ) # FatJet_particleNet_XbbVsQCD: ParticleNet X->bb vs. QCD score: Xbb/(Xbb+QCD)
+        )  # FatJet_particleNet_XbbVsQCD: ParticleNet X->bb vs. QCD score: Xbb/(Xbb+QCD)
         self.df = self.df.Define(
             "SelectedFatJet_idxUnordered",
             "CreateIndexes(SelectedFatJet_p4[fatJet_sel].size())",

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -309,7 +309,7 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         # Run 3
         self.df = self.df.Define(
             "SelectedFatJet_particleNet_XbbVsQCD_boosted_vec",
-            "SelectedFatJet_particleNet_XbbVsQCD[fatJet_sel];" # FatJet_particleNet_XbbVsQCD: ParticleNet X->bb vs. QCD score: Xbb/(Xbb+QCD)
+            "SelectedFatJet_particleNet_XbbVsQCD[fatJet_sel];",# FatJet_particleNet_XbbVsQCD: ParticleNet X->bb vs. QCD score: Xbb/(Xbb+QCD)
         )
         self.df = self.df.Define(
             "SelectedFatJet_idxUnordered",

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -309,8 +309,8 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         # Run 3
         self.df = self.df.Define(
             "SelectedFatJet_particleNet_XbbVsQCD_boosted_vec",
-            "SelectedFatJet_particleNet_XbbVsQCD[fatJet_sel];",# FatJet_particleNet_XbbVsQCD: ParticleNet X->bb vs. QCD score: Xbb/(Xbb+QCD)
-        )
+            f"SelectedFatJet_particleNet_XbbVsQCD[fatJet_sel];",
+        ) # FatJet_particleNet_XbbVsQCD: ParticleNet X->bb vs. QCD score: Xbb/(Xbb+QCD)
         self.df = self.df.Define(
             "SelectedFatJet_idxUnordered",
             "CreateIndexes(SelectedFatJet_p4[fatJet_sel].size())",

--- a/Studies/MassCuts/GetIntervalsSimultaneously.py
+++ b/Studies/MassCuts/GetIntervalsSimultaneously.py
@@ -32,7 +32,7 @@ def GetMassCut(
                 ### boosted_cat_3 redefinition: to apply also mass cuts ####
                 df_ch = df_ch.Define(
                     "boosted_cat_3",
-                    "boosted && !(res2b_cat3 && tautau_m_vis > 15 && tautau_m_vis < 130 && bb_m_vis < 270 && bb_m_vis>20)",
+                    "boosted && !(res2b && tautau_m_vis > 15 && tautau_m_vis < 130 && bb_m_vis < 270 && bb_m_vis>20)",
                 ).Filter("boosted_cat_3")
 
                 masses_boosted = [
@@ -111,7 +111,7 @@ def GetMassCut(
                 df_ch = (
                     df_ch.Define(
                         "boosted_cat3_SR",
-                        "boosted && !(res2b_cat3 && tautau_m_vis > 15 && tautau_m_vis < 130 && bb_m_vis < 270 && bb_m_vis>20) && (res2b_cat3 && tautau_m_vis > 15 && tautau_m_vis < 130 && bb_m_vis_boosted_softdrop < 450 && bb_m_vis_boosted_softdrop>30)",
+                        "boosted && !(res2b && tautau_m_vis > 15 && tautau_m_vis < 130 && bb_m_vis < 270 && bb_m_vis>20) && (res2b && tautau_m_vis > 15 && tautau_m_vis < 130 && bb_m_vis_boosted_softdrop < 450 && bb_m_vis_boosted_softdrop>30)",
                     )
                     .Define("res1b_cat3_SR", "!(boosted_cat3_SR)")
                     .Filter("res1b_cat3_SR")

--- a/Studies/MassCuts/KinFitMass_distributions.py
+++ b/Studies/MassCuts/KinFitMass_distributions.py
@@ -413,11 +413,11 @@ if __name__ == "__main__":
         res_str = "rad"
     for channel in ["eTau", "muTau", "tauTau"]:
         for cat in [
-            "res1b_cat3_masswindow",
-            "res2b_cat3_masswindow",
-            "boosted_cat3_masswindow",
-            "baseline_masswindow",
-            "inclusive_masswindow",
+            # "res1b_cat3_masswindow",
+            # "res2b_cat3_masswindow",
+            # "boosted_cat3_masswindow",
+            # "baseline_masswindow",
+            # "inclusive_masswindow",
             "baseline",
             "inclusive",
         ]:

--- a/Studies/MassCuts/MassCutHistograms.py
+++ b/Studies/MassCuts/MassCutHistograms.py
@@ -107,7 +107,9 @@ def Plot2DMassRes1b(
         .GetValue()
     )
     hist_num = (
-        df.Filter(f"OS_Iso && {channel} && (!(res2b) && !(!(res2b) && (boosted_baseline)) && nSelBtag == 1)")
+        df.Filter(
+            f"OS_Iso && {channel} && (!(res2b) && !(!(res2b) && (boosted_baseline)) && nSelBtag == 1)"
+        )
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis", "tautau_m_vis")
         .GetValue()
     )
@@ -277,9 +279,7 @@ def Plot2DMassboosted(
     x_bins = hist_cfg_dict["bb_m_vis"]["x_rebin"]["boosted"]
     y_bins = hist_cfg_dict["tautau_m_vis"]["x_rebin"]["other"]
     hist_denum = (
-        df.Filter(
-            f"OS_Iso && {channel} && !(res2b) && boosted"
-        )
+        df.Filter(f"OS_Iso && {channel} && !(res2b) && boosted")
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis_softdrop", "tautau_m_vis")
         .GetValue()
     )

--- a/Studies/MassCuts/MassCutHistograms.py
+++ b/Studies/MassCuts/MassCutHistograms.py
@@ -101,13 +101,13 @@ def Plot2DMassRes1b(
     y_bins = hist_cfg_dict["tautau_m_vis"]["x_rebin"]["other"]
     hist_denum = (
         df.Filter(
-            f"OS_Iso && {channel} && !(res2b_cat3) && !(boosted_baseline_cat3) && nSelBtag == 1"
+            f"OS_Iso && {channel} && !(res2b) && !(!(res2b) && (boosted_baseline)) && nSelBtag == 1"
         )
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis", "tautau_m_vis")
         .GetValue()
     )
     hist_num = (
-        df.Filter(f"OS_Iso && {channel} && res1b_cat3")
+        df.Filter(f"OS_Iso && {channel} && (!(res2b) && !(!(res2b) && (boosted_baseline)) && nSelBtag == 1)")
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis", "tautau_m_vis")
         .GetValue()
     )
@@ -189,12 +189,12 @@ def Plot2DMassRes2b(
     x_bins = hist_cfg_dict["bb_m_vis"]["x_rebin"]["other"]
     y_bins = hist_cfg_dict["tautau_m_vis"]["x_rebin"]["other"]
     hist_denum = (
-        df.Filter(f"OS_Iso && {channel} && res2b_inclusive")
+        df.Filter(f"OS_Iso && {channel} && res2b")
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis", "tautau_m_vis")
         .GetValue()
     )
     hist_num = (
-        df.Filter(f"OS_Iso && {channel} && res2b_cat3")
+        df.Filter(f"OS_Iso && {channel} && res2b")
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis", "tautau_m_vis")
         .GetValue()
     )
@@ -274,17 +274,17 @@ def Plot2DMassboosted(
     mass="1250",
     resonance="",
 ):
-    x_bins = hist_cfg_dict["bb_m_vis"]["x_rebin"]["boosted_cat3_masswindow"]
+    x_bins = hist_cfg_dict["bb_m_vis"]["x_rebin"]["boosted"]
     y_bins = hist_cfg_dict["tautau_m_vis"]["x_rebin"]["other"]
     hist_denum = (
         df.Filter(
-            f"OS_Iso && {channel} && !(res2b_cat3) && SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0"
+            f"OS_Iso && {channel} && !(res2b) && boosted"
         )
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis_softdrop", "tautau_m_vis")
         .GetValue()
     )
     hist_num = (
-        df.Filter(f"OS_Iso && {channel} && boosted_cat3")
+        df.Filter(f"OS_Iso && {channel} && !(res2b) && boosted")
         .Histo2D(GetModel2D(x_bins, y_bins), "bb_m_vis", "tautau_m_vis")
         .GetValue()
     )

--- a/Studies/MassCuts/massCut_TTCR.py
+++ b/Studies/MassCuts/massCut_TTCR.py
@@ -4,7 +4,6 @@ import sys
 import yaml
 import numpy as np
 
-
 if __name__ == "__main__":
     sys.path.append(os.environ["ANALYSIS_PATH"])
 

--- a/Studies/MassCuts/massCut_TTCR.py
+++ b/Studies/MassCuts/massCut_TTCR.py
@@ -55,7 +55,7 @@ if __name__ == "__main__":
         dfWrapped_DY,
         global_cfg_dict,
         global_cfg_dict["channels_to_consider"],
-        ["inclusive", "res2b_cat3"],
+        ["inclusive", "res2b"],
         0.95,
     )
 
@@ -136,7 +136,7 @@ if __name__ == "__main__":
         dfWrapped,
         global_cfg_dict,
         global_cfg_dict["channels_to_consider"],
-        ["inclusive", "res2b_cat3"],
+        ["inclusive", "res2b"],
         0.90,
     )
     # GetIntervals.GetMassCut(dfWrapped,global_cfg_dict,global_cfg_dict['channels_to_consider'], 0.99)

--- a/Studies/MassCuts/massCut_signals.py
+++ b/Studies/MassCuts/massCut_signals.py
@@ -4,7 +4,6 @@ import sys
 import yaml
 import numpy as np
 
-
 if __name__ == "__main__":
     sys.path.append(os.environ["ANALYSIS_PATH"])
 

--- a/Studies/MassCuts/massCut_signals.py
+++ b/Studies/MassCuts/massCut_signals.py
@@ -113,7 +113,7 @@ if __name__ == "__main__":
     dfWrapped.df = dfWrapped.df.Define(
         "bb_m_vis_pnet",
         f"""
-                   if (!boosted || !boosted_cat3 || !boosted_inclusive){{
+                   if (!boosted || !(!(res2b) && boosted) || !boosted_inclusive){{
                        return static_cast<float>((b1_p4+b2_p4).M());
                        }}
                     return static_cast<float>(SelectedFatJet_{particleNet_mass}_boosted);""",
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     dfWrapped.df = dfWrapped.df.Define(
         "bb_m_vis_boosted_softdrop",
         f"""
-                   if (!boosted || !boosted_cat3 || !boosted_inclusive){{
+                   if (!boosted || !(!(res2b) && boosted) || !boosted_inclusive){{
                        return static_cast<float>((b1_p4+b2_p4).M());
                        }}
                     return static_cast<float>(SelectedFatJet_msoftdrop_boosted);""",
@@ -129,7 +129,7 @@ if __name__ == "__main__":
     dfWrapped.df = dfWrapped.df.Define(
         "bb_m_vis_boosted_fjmass",
         f"""
-                   if (!boosted || !boosted_cat3 || !boosted_inclusive){{
+                   if (!boosted || !(!(res2b) && boosted) || !boosted_inclusive){{
                        return static_cast<float>((b1_p4+b2_p4).M());
                        }}
                     return static_cast<float>(SelectedFatJet_mass_boosted);""",
@@ -140,10 +140,7 @@ if __name__ == "__main__":
             dfWrapped,
             global_cfg_dict,
             ["eTau", "muTau", "tauTau"],
-            [
-                "res2b_cat3",
-                "res2b_cat2",
-            ],
+            ["res2b"],
             0.99,
         )
     if args.cat == "res1b":

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -247,7 +247,7 @@ category_definition:
   res0b_inclusive: "nSelBtag == 0"
   res1b_inclusive: "nSelBtag == 1"
   res2b_inclusive: "nSelBtag == 2"
-  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0"
+  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0"
   res0b_cat2: "!boosted_baseline && nSelBtag == 0 "
   res1b_cat2: "!boosted_baseline && nSelBtag == 1 "
   res2b_cat2: "!boosted_baseline && nSelBtag == 2 "
@@ -281,6 +281,10 @@ category_definition:
   boosted_cat3_masswindow: "!(res2b_cat3_masswindow) && boosted_masswindow"  # (SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0) && {region}_boosted"
   res1b_cat3_masswindow: "!(res2b_cat3_masswindow) && !(boosted_baseline_cat3) && nSelBtag == 1 && {region}"
   res0b_cat3_masswindow: "!(res2b_cat3_masswindow) && !(boosted_baseline_cat3) && nSelBtag == 0 && {region}"
+
+boosted_fatjet_presel:
+  pt: 300
+  eta: 2.5
 
 singleMu_th:
   "Run2_2016": 26

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -242,17 +242,17 @@ application_regions:
 
 category_definition:
   # w/o mass window
-
+  
   # boosted_baseline: "(SelectedFatJet_p4[fatJet_sel].size()>0)"
   inclusive: "b2_pt>0"  # "!(boosted_baseline)"
   btag_shape: "!(boosted_baseline)"
   baseline: "return true;"
+  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0"
+  res2b: "nSelBtag == 2"
+  res1b: "nSelBtag == 1"
   res0b_inclusive: "nSelBtag == 0"
   res1b_inclusive: "nSelBtag == 1"
   res2b_inclusive: "nSelBtag == 2"
-  res1b: "nSelBtag == 1"
-  res2b: "nSelBtag == 2"
-  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0"
   res0b_cat2: "!boosted_baseline && nSelBtag == 0 "
   res1b_cat2: "!boosted_baseline && nSelBtag == 1 "
   res2b_cat2: "!boosted_baseline && nSelBtag == 2 "

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -128,8 +128,7 @@ QCDRegions:
   - SS_Iso
   - OS_AntiIso
   - SS_AntiIso
-boosted_categories:
-  - boosted_cat3_masswindow
+boosted_categories: []
 categories:
   - inclusive
   - baseline

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -222,6 +222,16 @@ category_definition:
   btag_shape: "!(boosted_baseline)"
   vbf_inclusive: "nVBFJet >= 2"
 
+  res0b_inclusive: "nSelBtag == 0"
+  res1b_inclusive: "nSelBtag == 1"
+  res2b_inclusive: "nSelBtag == 2"
+  res2b_cat2: "!boosted_baseline && nSelBtag == 2 "
+  boosted_cat2: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0 "
+  res2b_cat3: "nSelBtag == 2"
+  boosted_baseline_cat3: "!(res2b_cat3) && (boosted_baseline)"
+  boosted_cat3: "!(res2b_cat3) && boosted"
+  res1b_cat3: "!(res2b_cat3) && !(boosted_baseline_cat3) && nSelBtag == 1"
+
   # w/ mass window
   inclusive_masswindow: "!(boosted_baseline) && {region}"
   btag_shape_masswindow: "!(boosted_baseline) && {region}"

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -128,7 +128,7 @@ QCDRegions:
   - SS_Iso
   - OS_AntiIso
   - SS_AntiIso
-boosted_categories: []
+boosted_categories: [ ]
 categories:
   - inclusive
   - baseline

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -242,12 +242,12 @@ application_regions:
 
 category_definition:
   # w/o mass window
-  
+
   # boosted_baseline: "(SelectedFatJet_p4[fatJet_sel].size()>0)"
   inclusive: "b2_pt>0"  # "!(boosted_baseline)"
   btag_shape: "!(boosted_baseline)"
   baseline: "return true;"
-  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0"
+  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_XbbVsQCD>={pNetWP}].size()>0"
   res2b: "nSelBtag == 2"
   res1b: "nSelBtag == 1"
   res0b_inclusive: "nSelBtag == 0"

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -247,7 +247,7 @@ category_definition:
   inclusive: "b2_pt>0"  # "!(boosted_baseline)"
   btag_shape: "!(boosted_baseline)"
   baseline: "return true;"
-  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_XbbVsQCD>={pNetWP}].size()>0"
+  boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_pt>300 && abs(SelectedFatJet_eta)<2.5 && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_XbbVsQCD>={pNetWP}].size()>0"
   res2b: "nSelBtag == 2"
   res1b: "nSelBtag == 1"
   res0b_inclusive: "nSelBtag == 0"
@@ -286,10 +286,6 @@ category_definition:
   boosted_cat3_masswindow: "!(res2b_cat3_masswindow) && boosted_masswindow"  # (SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0) && {region}_boosted"
   res1b_cat3_masswindow: "!(res2b_cat3_masswindow) && !(boosted_baseline_cat3) && nSelBtag == 1 && {region}"
   res0b_cat3_masswindow: "!(res2b_cat3_masswindow) && !(boosted_baseline_cat3) && nSelBtag == 0 && {region}"
-
-boosted_fatjet_presel:
-  pt: 300
-  eta: 2.5
 
 singleMu_th:
   "Run2_2016": 26

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -136,8 +136,6 @@ categories:
   - boosted
   - res2b
   - res1b
-  - boosted_baseline
-  - vbf_inclusive
 
 requireHbbJets: False
 storeExtraJets: False
@@ -212,46 +210,12 @@ application_regions:
   # MET_region: (!(Legacy_region) && !(SingleTau_region))
 
 category_definition:
-  # w/o mass window
 
   baseline: "return true;"
   inclusive: "b2_pt>0"
   boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_pt>300 && abs(SelectedFatJet_eta)<2.5 && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_XbbVsQCD>={pNetWP}].size()>0"
   res2b: "nSelBtag == 2 && !(boosted)"
   res1b: "nSelBtag == 1 && !(boosted)"
-  btag_shape: "!(boosted_baseline)"
-  vbf_inclusive: "nVBFJet >= 2"
-
-  res0b_inclusive: "nSelBtag == 0"
-  res1b_inclusive: "nSelBtag == 1"
-  res2b_inclusive: "nSelBtag == 2"
-  res2b_cat2: "!boosted_baseline && nSelBtag == 2 "
-  boosted_cat2: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0 "
-  res2b_cat3: "nSelBtag == 2"
-  boosted_baseline_cat3: "!(res2b_cat3) && (boosted_baseline)"
-  boosted_cat3: "!(res2b_cat3) && boosted"
-  res1b_cat3: "!(res2b_cat3) && !(boosted_baseline_cat3) && nSelBtag == 1"
-
-  # w/ mass window
-  inclusive_masswindow: "!(boosted_baseline) && {region}"
-  btag_shape_masswindow: "!(boosted_baseline) && {region}"
-  baseline_masswindow: "return {region};"
-  res0b_inclusive_masswindow: "nSelBtag == 0 && {region}"
-  res1b_inclusive_masswindow: "nSelBtag == 1 && {region}"
-  res2b_inclusive_masswindow: "nSelBtag == 2 && {region}"
-
-  boosted_baseline_masswindow: "(SelectedFatJet_p4[fatJet_sel].size()>0) && {region}_boosted"
-  boosted_masswindow: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0 && {region}_boosted"
-  res0b_cat2_masswindow: "!boosted_baseline && nSelBtag == 0 && {region}"
-  res1b_cat2_masswindow: "!boosted_baseline && nSelBtag == 1 && {region}"
-  res2b_cat2_masswindow: "!boosted_baseline && nSelBtag == 2 && {region}"
-  boosted_cat2_masswindow: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0 && {region}_boosted"
-
-  res2b_cat3_masswindow: "nSelBtag == 2 && {region}"
-  boosted_baseline_cat3_masswindow: "!(res2b_cat3_masswindow) && (boosted_baseline)"
-  boosted_cat3_masswindow: "!(res2b_cat3_masswindow) && boosted_masswindow"  # (SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0) && {region}_boosted"
-  res1b_cat3_masswindow: "!(res2b_cat3_masswindow) && !(boosted_baseline_cat3) && nSelBtag == 1 && {region}"
-  res0b_cat3_masswindow: "!(res2b_cat3_masswindow) && !(boosted_baseline_cat3) && nSelBtag == 0 && {region}"
 
 singleMu_th:
   "Run2_2016": 26

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -215,11 +215,10 @@ category_definition:
   # w/o mass window
 
   baseline: "return true;"
-  inclusive: "b2_pt>0"  # "!(boosted_baseline)"
+  inclusive: "b2_pt>0"
   boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_pt>300 && abs(SelectedFatJet_eta)<2.5 && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_XbbVsQCD>={pNetWP}].size()>0"
   res2b: "nSelBtag == 2 && !(boosted)"
   res1b: "nSelBtag == 1 && !(boosted)"
-  boosted_baseline: "(SelectedFatJet_p4[fatJet_sel].size()>0)"
   btag_shape: "!(boosted_baseline)"
   vbf_inclusive: "nVBFJet >= 2"
 

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -137,14 +137,16 @@ boosted_categories:
 categories:
   - inclusive
   - baseline
+  - boosted
+  - res2b
+  - res1b
   - boosted_baseline
   # - boosted_baseline_cat3
   # - boosted_baseline_masswindow
   # - boosted_baseline_cat3_masswindow
-  - res0b_inclusive
-  - res1b_inclusive
-  - res2b_inclusive
-  - boosted
+  # - res0b_inclusive
+  # - res1b_inclusive
+  # - res2b_inclusive
   # - boosted_cat3
   # - res0b_cat2
   # - res1b_cat2
@@ -247,6 +249,8 @@ category_definition:
   res0b_inclusive: "nSelBtag == 0"
   res1b_inclusive: "nSelBtag == 1"
   res2b_inclusive: "nSelBtag == 2"
+  res1b: "nSelBtag == 1"
+  res2b: "nSelBtag == 2"
   boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0"
   res0b_cat2: "!boosted_baseline && nSelBtag == 0 "
   res1b_cat2: "!boosted_baseline && nSelBtag == 1 "

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -129,10 +129,6 @@ QCDRegions:
   - OS_AntiIso
   - SS_AntiIso
 boosted_categories:
-  # - boosted_cat2
-  # - boosted_cat3
-  # - boosted_masswindow
-  # - boosted_cat2_masswindow
   - boosted_cat3_masswindow
 categories:
   - inclusive
@@ -141,31 +137,6 @@ categories:
   - res2b
   - res1b
   - boosted_baseline
-  # - boosted_baseline_cat3
-  # - boosted_baseline_masswindow
-  # - boosted_baseline_cat3_masswindow
-  # - res0b_inclusive
-  # - res1b_inclusive
-  # - res2b_inclusive
-  # - boosted_cat3
-  # - res0b_cat2
-  # - res1b_cat2
-  # - res2b_cat2
-  # - res2b_cat3
-  # - res1b_cat3
-  # - res0b_cat3
-  # - inclusive_masswindow
-  # - btag_shape_masswindow
-  # - baseline_masswindow
-  # - res0b_inclusive_masswindow
-  # - res1b_inclusive_masswindow
-  # - res2b_inclusive_masswindow
-  # - res0b_cat2_masswindow
-  # - res1b_cat2_masswindow
-  # - res2b_cat2_masswindow
-  # - res2b_cat3_masswindow
-  # - res1b_cat3_masswindow
-  # - res0b_cat3_masswindow
   - vbf_inclusive
 
 requireHbbJets: False
@@ -243,30 +214,16 @@ application_regions:
 category_definition:
   # w/o mass window
 
-  # boosted_baseline: "(SelectedFatJet_p4[fatJet_sel].size()>0)"
-  inclusive: "b2_pt>0"  # "!(boosted_baseline)"
-  btag_shape: "!(boosted_baseline)"
   baseline: "return true;"
+  inclusive: "b2_pt>0"  # "!(boosted_baseline)"
   boosted: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_pt>300 && abs(SelectedFatJet_eta)<2.5 && SelectedFatJet_msoftdrop > 80 && SelectedFatJet_msoftdrop < 170 && SelectedFatJet_particleNet_XbbVsQCD>={pNetWP}].size()>0"
-  res2b: "nSelBtag == 2"
-  res1b: "nSelBtag == 1"
-  res0b_inclusive: "nSelBtag == 0"
-  res1b_inclusive: "nSelBtag == 1"
-  res2b_inclusive: "nSelBtag == 2"
-  res0b_cat2: "!boosted_baseline && nSelBtag == 0 "
-  res1b_cat2: "!boosted_baseline && nSelBtag == 1 "
-  res2b_cat2: "!boosted_baseline && nSelBtag == 2 "
-  boosted_cat2: "SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0 "
-  res2b_cat3: "nSelBtag == 2"
-  boosted_baseline_cat3: "!(res2b_cat3) && (boosted_baseline)"
-  boosted_cat3: "!(res2b_cat3) && boosted"  # (SelectedFatJet_p4[fatJet_sel && SelectedFatJet_particleNet_MD_JetTagger>={pNetWP}].size()>0) && {region}_boosted"
-  res1b_cat3: "!(res2b_cat3) && !(boosted_baseline_cat3) && nSelBtag == 1"
-  res0b_cat3: "!(res2b_cat3) && !(boosted_baseline_cat3) && nSelBtag == 0"
-
+  res2b: "nSelBtag == 2 && !(boosted)"
+  res1b: "nSelBtag == 1 && !(boosted)"
+  boosted_baseline: "(SelectedFatJet_p4[fatJet_sel].size()>0)"
+  btag_shape: "!(boosted_baseline)"
   vbf_inclusive: "nVBFJet >= 2"
 
   # w/ mass window
-  # boosted_baseline: "(SelectedFatJet_p4[fatJet_sel].size()>0)" (commenting this out because it has been defined under w/o mass window already)
   inclusive_masswindow: "!(boosted_baseline) && {region}"
   btag_shape_masswindow: "!(boosted_baseline) && {region}"
   baseline_masswindow: "return {region};"


### PR DESCRIPTION
In early run-3 AN:
1. bb-boosted: events where an AK8 jet with pT > 300 GeV, |η|< 2.5 and 80 < mSD < 170 GeV satisfies the custom working point of ParticleNet: cut at 0.75 was selected as optimal because it achieved the best balance between retaining signal events and rejecting background, leading to the best expected limit (section 6.2.1)
2. res2b: events where the two AK4 jets with the highest HHBTag score both pass the medium ParticleNet b-tagging WP
3. res1b: events where only one of the two AK4 jets with the highest HHBTag score passes the medium ParticleNet b-tagging WP, while the second does not.

Related to https://github.com/cms-flaf/HH_bbtautau_planning/issues/82