### PR TITLE
Fix nTags which are now nBjets with  PNetTagged with Medium_WP(>=2)

### DIFF
--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -198,11 +198,9 @@ def GetBTagWeight(global_cfg_dict, cat, applyBtag=False):
     return f"{btag_weight}*{btagshape_weight}"
 
 
-# def GetWeight(channels, weights_this_process=None, isDY=False):
 def GetWeight(channels, weights_this_process=None):
     weights_dict = {}
     weights_this_process = set(weights_this_process or [])
-    # apply_dy_hhbbtautau = isDY or ("dy_hhbbtautau" in weights_this_process)
     apply_dy_hhbbtautau = False
     if "dy_hhbbtautau" in weights_this_process:
         apply_dy_hhbbtautau = True

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -198,8 +198,10 @@ def GetBTagWeight(global_cfg_dict, cat, applyBtag=False):
     return f"{btag_weight}*{btagshape_weight}"
 
 
-def GetWeight(channels, isDY=False):
+def GetWeight(channels, weights_this_process=None, isDY=False):
     weights_dict = {}
+    weights_this_process = set(weights_this_process or [])
+    apply_dy_hhbbtautau = isDY or ("dy_hhbbtautau" in weights_this_process)
     weights_to_apply = [
         "weight_base"
     ]  # , "weight_L1PreFiring_Central","weight_L1PreFiring_ECAL_Central", "weight_L1PreFiring_Muon_Central"]
@@ -266,7 +268,7 @@ def GetWeight(channels, isDY=False):
         weights_list = ["weight_base"]
         # weights_list.extend(trg_weights_dict[channel]) ## currently commented because there are no trigger weights ??
         weights_list.extend(ID_weights_dict[channel])
-        if isDY:
+        if apply_dy_hhbbtautau:  # isDY:
             weights_list.append("weight_dy_central")
 
         # if categories dependent weights are present do a sub loop here extending the dict
@@ -479,10 +481,19 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
             )
 
     def defineCategories(self):  # needs lot of stuff --> at the end
-        self.df = self.df.Define(
-            "nSelBtag",
-            f"int(b1_btagDeepFlavB >{self.bTagWP}) + int(b2_btagDeepFlavB >{self.bTagWP})",
-        )
+
+        self.df = self.df.Define("bjet1_isValid", "nBJets > 0")
+        self.df = self.df.Define("bjet2_isValid", "nBJets > 1")
+
+        nBjets_PNetTag = f"int(bjet1_isValid && b1_idbtagPNetB >= 2) + int( bjet2_isValid && b2_idbtagPNetB >= 2)"
+        self.df = self.df.Redefine("nBJets", nBjets_PNetTag)
+
+        # self.df = self.df.Define(
+        #     "nSelBtag",
+        #     f"int(b1_btagDeepFlavB >{self.bTagWP}) + int(b2_btagDeepFlavB >{self.bTagWP})",
+        # )
+        self.df = self.df.Redefine("nSelBtag", nBjets_PNetTag)
+
         for category_to_def in self.config["category_definition"].keys():
             category_name = category_to_def
             if category_name == "boosted":

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -198,10 +198,14 @@ def GetBTagWeight(global_cfg_dict, cat, applyBtag=False):
     return f"{btag_weight}*{btagshape_weight}"
 
 
-def GetWeight(channels, weights_this_process=None, isDY=False):
+# def GetWeight(channels, weights_this_process=None, isDY=False):
+def GetWeight(channels, weights_this_process=None):
     weights_dict = {}
     weights_this_process = set(weights_this_process or [])
-    apply_dy_hhbbtautau = isDY or ("dy_hhbbtautau" in weights_this_process)
+    # apply_dy_hhbbtautau = isDY or ("dy_hhbbtautau" in weights_this_process)
+    apply_dy_hhbbtautau = False
+    if "dy_hhbbtautau" in weights_this_process:
+        apply_dy_hhbbtautau = True
     weights_to_apply = [
         "weight_base"
     ]  # , "weight_L1PreFiring_Central","weight_L1PreFiring_ECAL_Central", "weight_L1PreFiring_Muon_Central"]

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -492,7 +492,7 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         #     "nSelBtag",
         #     f"int(b1_btagDeepFlavB >{self.bTagWP}) + int(b2_btagDeepFlavB >{self.bTagWP})",
         # )
-        self.df = self.df.Redefine("nSelBtag", nBjets_PNetTag)
+        self.df = self.df.Define("nSelBtag", nBjets_PNetTag)
 
         for category_to_def in self.config["category_definition"].keys():
             category_name = category_to_def

--- a/Analysis/histTupleDef.py
+++ b/Analysis/histTupleDef.py
@@ -73,8 +73,8 @@ def DefineWeightForHistograms(
 ):
     global central_df_weights_computed
     is_central = uncName == central
+    corrections = Corrections.getGlobal()
     if not isData and (not central_df_weights_computed or not df_is_central):
-        corrections = Corrections.getGlobal()
         lepton_legs = ["tau1", "tau2"]
         offline_legs = ["tau1", "tau2", "b1", "b2"]
         triggers_to_use = set()
@@ -108,13 +108,14 @@ def DefineWeightForHistograms(
     boosted_categories = global_params.get("boosted_categories", [])
     process_group = global_params["process_group"]
 
-    isDY = process_group == "DY"
+    # isDY = process_group == "DY"
+    weights_this_process = set(corrections.to_apply.keys())
 
     total_weight_expression = (
         # channel, cat, boosted_categories --> these are not needed in the GetWeight function therefore I just put some placeholders
         analysis.GetWeight(
             global_params["channels_to_consider"],
-            isDY=isDY,
+            weights_this_process=weights_this_process,
         )
         if process_group != "data"
         else "1"

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -123,7 +123,7 @@ corrections:
     jetCollection: centralJet
   dy_hhbbtautau:
     stages: [ HistTuple ]
-    processes: [ DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]
+    processes: [ DY_M_10to50, DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]
   bosonicRecoil:
     stage: HistTuple
     method: QuantileMapHist # Rescaling


### PR DESCRIPTION
Summary

- B-tag category counting (nSelBtag/nBJets): replaced the DeepFlavB-threshold count (b1_btagDeepFlavB > bTagWP) with a PNet-based count using the Medium working point (idbtagPNetB >= 2), gated on jet validity (bjet1_isValid/bjet2_isValid). nBJets is now redefined from the PNet Medium-WP tag count, and nSelBtag is derived in the same way, so both b-tag category and shape-weight quantities use PNet Medium tagging consistently.
- DY weight application: GetWeight() no longer decides whether to apply weight_dy_central from the process-group label (isDY = process_group == "DY") alone. It now also applies the DY weight whenever the dy_hhbbtautau correction is active for the process (weights_this_process derived from corrections.to_apply.keys() in histTupleDef.py). This closes a gap where DY_M_10to50 was missing from the dy_hhbbtautau.processes list in config/global.yaml, so the weight is now correctly configured for that process too.

Why

The old nSelBtag used a raw DeepFlavB cut, inconsistent with the analysis's move to PNet tagging at Medium WP (>=2) for b-jet identification. The DY weight logic was tied only to process_group == "DY", which silently excluded DY_M_10to50 since it wasn't listed under dy_hhbbtautau corrections — this PR both generalizes this trigger condition and fixes the missing process entry.