### PR TITLE
Number of jets definition updated for DY correction

### DIFF
--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -711,7 +711,7 @@ def defineAllP4(df, isData=False):
     for idx in [0, 1]:
         df = Utilities.defineP4(df, f"tau{idx+1}")
         df = Utilities.defineP4(df, f"b{idx+1}")
-    df = df.Define("Njets", "nBJets") # nBJets = Jet_p4[Jet_bCand].size()
+    df = df.Define("Njets", "nBJets")  # nBJets = Jet_p4[Jet_bCand].size()
     if not isData:
         df = df.Define(f"pt_ll_gen", f"LHE_Vpt")
     for met_var in ["met", "metnomu"]:

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -711,6 +711,7 @@ def defineAllP4(df, isData=False):
     for idx in [0, 1]:
         df = Utilities.defineP4(df, f"tau{idx+1}")
         df = Utilities.defineP4(df, f"b{idx+1}")
+    df = df.Define("Njets", "nBJets") # nBJets = Jet_p4[Jet_bCand].size()
     if not isData:
         df = df.Define(f"pt_ll_gen", f"LHE_Vpt")
     for met_var in ["met", "metnomu"]:

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -488,7 +488,6 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         self.df = self.df.Define("bjet2_isValid", "nBJets > 1")
 
         nBjets_PNetTag = f"int(bjet1_isValid && b1_idbtagPNetB >= 2) + int( bjet2_isValid && b2_idbtagPNetB >= 2)"
-        self.df = self.df.Redefine("nBJets", nBjets_PNetTag)
 
         # self.df = self.df.Define(
         #     "nSelBtag",
@@ -711,7 +710,6 @@ def defineAllP4(df, isData=False):
     for idx in [0, 1]:
         df = Utilities.defineP4(df, f"tau{idx+1}")
         df = Utilities.defineP4(df, f"b{idx+1}")
-    df = df.Define("Njets", "nBJets")  # nBJets = Jet_p4[Jet_bCand].size()
     if not isData:
         df = df.Define(f"pt_ll_gen", f"LHE_Vpt")
     for met_var in ["met", "metnomu"]:

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -124,7 +124,7 @@ corrections:
   dy_hhbbtautau:
     stages: [ HistTuple ]
     processes: [ DY_M_10to50, DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]
-    njets_branch: Njets
+    njets_branch: nBJets
   bosonicRecoil:
     stage: HistTuple
     method: QuantileMapHist # Rescaling

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -124,6 +124,7 @@ corrections:
   dy_hhbbtautau:
     stages: [ HistTuple ]
     processes: [ DY_M_10to50, DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]
+    njets_branch: Njets
   bosonicRecoil:
     stage: HistTuple
     method: QuantileMapHist # Rescaling


### PR DESCRIPTION
`Analysis/hh_bbtautau.py`: 
`Njets = nBJets`, defined once in `defineAllP4()` function before `defineCategories()` function redefines `nBJets`: correct central-jet count for the DY correction.

`config/global.yaml`:
`njets_branch: Njets` added to `dy_hhbbtautau`, so the correction actually uses that branch instead of falling back to raw nJet.