### PR TITLE
Prepare HH_bbtautau for Run3_2024 and Run3_2025

### DIFF
--- a/.github/workflows/test-setup-loading.yaml
+++ b/.github/workflows/test-setup-loading.yaml
@@ -12,5 +12,5 @@ jobs:
   test-setup-loading:
     uses: cms-flaf/FLAF/.github/workflows/test-setup-loading.yaml@main
     with:
-      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024"
+      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024 Run3_2025"
     secrets: inherit

--- a/.github/workflows/test-setup-loading.yaml
+++ b/.github/workflows/test-setup-loading.yaml
@@ -12,5 +12,5 @@ jobs:
   test-setup-loading:
     uses: cms-flaf/FLAF/.github/workflows/test-setup-loading.yaml@main
     with:
-      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024 Run3_2025"
+      eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix Run3_2024 Run3_2025 Run3_2026"
     secrets: inherit

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -300,9 +300,6 @@ def addAllVariables(
     dfw.Apply(Corrections.getGlobal().btag.getWPid, "Jet")
     jet_obs = []
     jet_obs.extend(JetObservables)
-    if global_params["era"] in ("Run3_2024", "Run3_2025"):
-        # NanoAODv15 dropped the detailed Jet_puId_* inputs.
-        jet_obs = [v for v in jet_obs if not v.startswith("puId_")]
     if global_params["requireHbbJets"]:
         dfw.Apply(AnaBaseline.ApplyJetSelection)
     if not isData:
@@ -324,6 +321,9 @@ def addAllVariables(
                         f"genLepton{gen_idx+1}_{var}",
                         f"static_cast<float>(genHttCandidate->leg_p4[{gen_idx}].{var}())",
                     )
+
+    existing_cols = {str(c) for c in dfw.df.GetColumnNames()}
+    jet_obs = [v for v in jet_obs if f"Jet_{v}" in existing_cols]
 
     dfw.DefineAndAppend(f"nBJets", f"Jet_p4[Jet_bCand].size()")
 

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -300,6 +300,9 @@ def addAllVariables(
     dfw.Apply(Corrections.getGlobal().btag.getWPid, "Jet")
     jet_obs = []
     jet_obs.extend(JetObservables)
+    if global_params["era"] in ("Run3_2024", "Run3_2025"):
+        # NanoAODv15 dropped the detailed Jet_puId_* inputs.
+        jet_obs = [v for v in jet_obs if not v.startswith("puId_")]
     if global_params["requireHbbJets"]:
         dfw.Apply(AnaBaseline.ApplyJetSelection)
     if not isData:

--- a/AnaProd/anaTupleDef.py
+++ b/AnaProd/anaTupleDef.py
@@ -470,12 +470,16 @@ def addAllVariables(
         f"SelectedFatJet_mass", f"v_ops::mass(FatJet_p4[FatJet_bbCand])"
     )
 
+    existing_cols = {str(c) for c in dfw.df.GetColumnNames()}
+    fatjet_obs = [v for v in fatjet_obs if f"FatJet_{v}" in existing_cols]
     for fatjetVar in fatjet_obs:
         dfw.DefineAndAppend(
             f"SelectedFatJet_{fatjetVar}", f"FatJet_{fatjetVar}[FatJet_bbCand]"
         )
     subjet_obs = []
     subjet_obs.extend(SubJetObservables)
+    existing_cols = {str(c) for c in dfw.df.GetColumnNames()}
+    subjet_obs = [v for v in subjet_obs if f"SubJet_{v}" in existing_cols]
     if not isData:
         dfw.Define(
             f"SubJet1_genJet_idx",

--- a/Analysis/DNN_application.py
+++ b/Analysis/DNN_application.py
@@ -39,6 +39,8 @@ class DNNProducer:
         self.vars_to_save = load_features
 
     def load_models(self, model_dir):
+        if not os.path.isabs(model_dir):
+            model_dir = os.path.join(os.environ["ANALYSIS_PATH"], model_dir)
         models = [
             NNInterface(
                 fold_index=fold_index,

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -19,12 +19,17 @@ WorkingPointsParticleNet = {
     "Run3_2022EE": {"Loose": 0.0499, "Medium": 0.2605, "Tight": 0.6915},
     "Run3_2023": {"Loose": 0.0358, "Medium": 0.1917, "Tight": 0.6172},
     "Run3_2023BPix": {"Loose": 0.0359, "Medium": 0.1919, "Tight": 0.6133},
+    # UParTAK4 WP values from BTV Summer24 NanoAODv15 (L/M/T).
+    "Run3_2024": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
+    "Run3_2025": {"Loose": 0.0246, "Medium": 0.1272, "Tight": 0.4648},
 }
 WorkingPointsDeepFlav = {
     "Run3_2022": {"Loose": 0.0583, "Medium": 0.3086, "Tight": 0.7183},
     "Run3_2022EE": {"Loose": 0.0614, "Medium": 0.3196, "Tight": 0.73},
     "Run3_2023": {"Loose": 0.0479, "Medium": 0.2431, "Tight": 0.6553},
     "Run3_2023BPix": {"Loose": 0.048, "Medium": 0.2435, "Tight": 0.6563},
+    "Run3_2024": {"Loose": 0.048, "Medium": 0.2435, "Tight": 0.6563},
+    "Run3_2025": {"Loose": 0.048, "Medium": 0.2435, "Tight": 0.6563},
 }
 
 

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -198,14 +198,14 @@ def GetBTagWeight(global_cfg_dict, cat, applyBtag=False):
     return f"{btag_weight}*{btagshape_weight}"
 
 
-def GetWeight(channels, weights_this_process=None):
+def GetWeight(channels, weights_this_process=None, weight_base_name="weight_base"):
     weights_dict = {}
     weights_this_process = set(weights_this_process or [])
     apply_dy_hhbbtautau = False
     if "dy_hhbbtautau" in weights_this_process:
         apply_dy_hhbbtautau = True
     weights_to_apply = [
-        "weight_base"
+        weight_base_name
     ]  # , "weight_L1PreFiring_Central","weight_L1PreFiring_ECAL_Central", "weight_L1PreFiring_Muon_Central"]
     trg_weights_dict = {
         "eTau": [
@@ -267,7 +267,7 @@ def GetWeight(channels, weights_this_process=None):
     }
     weights_full_string = ""
     for channel in channels:
-        weights_list = ["weight_base"]
+        weights_list = [weight_base_name]
         # weights_list.extend(trg_weights_dict[channel]) ## currently commented because there are no trigger weights ??
         weights_list.extend(ID_weights_dict[channel])
         if apply_dy_hhbbtautau:  # isDY:

--- a/Analysis/hh_bbtautau.py
+++ b/Analysis/hh_bbtautau.py
@@ -492,7 +492,19 @@ class DataFrameBuilderForHistograms(DataFrameBuilderBase):
         self.df = self.df.Define("bjet1_isValid", "nBJets > 0")
         self.df = self.df.Define("bjet2_isValid", "nBJets > 1")
 
-        nBjets_PNetTag = f"int(bjet1_isValid && b1_idbtagPNetB >= 2) + int( bjet2_isValid && b2_idbtagPNetB >= 2)"
+        cols = {str(c) for c in self.df.GetColumnNames()}
+        if "b1_idbtagPNetB" in cols:
+            nBjets_PNetTag = (
+                "int(bjet1_isValid && b1_idbtagPNetB >= 2) "
+                "+ int(bjet2_isValid && b2_idbtagPNetB >= 2)"
+            )
+        else:
+            score = "btagUParTAK4B" if "b1_btagUParTAK4B" in cols else "btagPNetB"
+            wp = WorkingPointsParticleNet[self.period]["Medium"]
+            nBjets_PNetTag = (
+                f"int(bjet1_isValid && b1_{score} >= {wp}) "
+                f"+ int(bjet2_isValid && b2_{score} >= {wp})"
+            )
         self.df = self.df.Redefine("nBJets", nBjets_PNetTag)
 
         # self.df = self.df.Define(

--- a/Analysis/histTupleDef.py
+++ b/Analysis/histTupleDef.py
@@ -116,6 +116,7 @@ def DefineWeightForHistograms(
         analysis.GetWeight(
             global_params["channels_to_consider"],
             weights_this_process=weights_this_process,
+            weight_base_name=global_params.get("weight_base_branch", "weight_base"),
         )
         if process_group != "data"
         else "1"

--- a/config/Run3_2024/datasets.yaml
+++ b/config/Run3_2024/datasets.yaml
@@ -224,96 +224,134 @@ GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_0p00:
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_0p00
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-0p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_1p00:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_1p00
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-1p00-kl-0p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-0p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p10:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p10
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-0p10-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p35:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p35
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-0p35-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_3p00:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_3p00
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-3p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_m2p00:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_m2p00
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-m2p00-kl-1p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_2p45_kt_1p00_c2_0p00:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_2p45_kt_1p00_c2_0p00
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-0p00-kl-2p45-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 GluGlutoHHto2B2Tau_kl_5p00_kt_1p00_c2_0p00:
   generator: powheg
   mass: 125
   spin: 0
   crossSection: GluGlutoHHto2B2Tau_kl_5p00_kt_1p00_c2_0p00
+  nanoAOD:
+    v15: /GluGluHHto2B2Tau_Par-c2-0p00-kl-5p00-kt-1p00_TuneCP5_13p6TeV_powheg-pythia8/RunIII2024Summer24NanoAODv15-PowhegBugFix_150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_1_C2V_0_C3_1_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-1-C2V-0-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_1_C2V_1_C3_1_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-1-C2V-1-C3-1_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_1p74_C2V_1p37_C3_14p4_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV1p74-C2V-1p37-C3-14p4_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_2p12_C2V_3p87_C3_m5p96_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-2p12-C2V-3p87-C3-m5p96_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_m0p012_C2V_0p030_C3_10p2_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-m0p012-C2V-0p030-C3-10p2_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_m0p758_C2V_1p44_C3_m19p3_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-m0p758-C2V-1p44-C3-m19p3_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_m0p962_C2V_0p959_C3_m1p43_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-m0p962-C2V-0p959-C3-m1p43_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_m1p21_C2V_1p94_C3_m0p94_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-m1p21-C2V-1p94-C3-m0p94_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_m1p60_C2V_2p72_C3_m1p36_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-m1p60-C2V-2p72-C3-m1p36_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 VBFHHto2B2Tau_CV_m1p83_C2V_3p57_C3_m3p39_fixedTauDecays:
   generator: madgraph
   mass: 125
   spin: 0
   crossSection: 1pb
+  nanoAOD:
+    v15: /VBFHHto2B2Tau_Par-CV-m1p83-C2V-3p57-C3-m3p39_TuneCP5_13p6TeV_madgraph-pythia8/RunIII2024Summer24NanoAODv15-150X_mcRun3_2024_realistic_v2-v2/NANOAODSIM
 
 
 custom_CI:

--- a/config/Run3_2024/global.yaml
+++ b/config/Run3_2024/global.yaml
@@ -1,4 +1,8 @@
 triggerFile: config/Run3_2024/triggers.yaml
+nano_version: v15
+nanoAODVersions:
+  data: v15
+  mc: v15
 corrections:
   lumi: { stage: AnaTuple }
   xs: { stage: AnaTuple }

--- a/config/Run3_2024/global.yaml
+++ b/config/Run3_2024/global.yaml
@@ -1,8 +1,45 @@
 triggerFile: config/Run3_2024/triggers.yaml
 corrections:
+  lumi: { stage: AnaTuple }
+  xs: { stage: AnaTuple }
+  gen: { stage: AnaTuple }
+  pu:
+    stages: [ AnaTuple, AnaTupleMerge ]
+    enabled:
+      AnaTuple: true
+      AnaTupleMerge: false
+  base: { stage: AnaTupleMerge }
+  tauID: { stage: HistTuple }
+  tauES: { stage: AnaTuple }
+  mu:
+    stage: HistTuple
+    columns:
+      pfRelIso04_all: Muon_pfRelIso04_all
+      tightId: Muon_tightId
+      tkRelIso: Muon_tkRelIso
+      highPtId: Muon_highPtId
+      mediumId: Muon_mediumId
+      looseId: Muon_looseId
+  trigger:
+    stage: HistTuple
+    mode: efficiency
+  ele: { stage: HistTuple }
+  muScaRe: { stage: AnaTuple, mu_pt_for_ScaReApplication: "nano" }
+  eleES: { stage: AnaTuple }
+  JEC: { stage: AnaTuple }
+  JER:
+    stage: AnaTuple
+    apply_jet_horns_fix: true
   btag:
     stages: [ AnaTuple ]
     modes:
       AnaTuple: none
     tagger: UParTAK4
     jetCollection: centralJet
+  dy_hhbbtautau:
+    stages: [ HistTuple ]
+    processes: [ DY_M_10to50, DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]
+  bosonicRecoil:
+    stage: HistTuple
+    method: QuantileMapHist
+    apply_systematics: true

--- a/config/Run3_2024/global.yaml
+++ b/config/Run3_2024/global.yaml
@@ -36,6 +36,7 @@ corrections:
       AnaTuple: none
     tagger: UParTAK4
     jetCollection: centralJet
+    wantShape: false
   dy_hhbbtautau:
     stages: [ HistTuple ]
     processes: [ DY_M_10to50, DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -50,6 +50,7 @@ DYto2Mu_M_50:
 DYto2Tau_M_50:
   processors: *DY_processors
   datasets:
+    - DYto2Tau_M_50_amcatnloFXFX
     - DYto2Tau_M_50_0J_amcatnloFXFX
     - DYto2Tau_M_50_1J_amcatnloFXFX
     - DYto2Tau_M_50_2J_amcatnloFXFX
@@ -60,17 +61,28 @@ DYto2Tau_M_50:
 
 TT:
   name: "t#bar{t}"
-  color: "kGreen-3"  # eliminates need for plot.yaml
+  color: "kGreen-3"
   datasets:
     - TTto2L2Nu
     - TTtoLNu2Q
     - TTto4Q
 
-
 ST:
   name: "Single Top"
   color: "kGreen-5"
-  datasets: [ ]
+  datasets:
+    - TbarBtoLminusNuB_s_channel_4FS
+    - TBbartoLplusNuBbar_s_channel_4FS
+    - TbarBQtoLNu_t_channel_4FS
+    - TbarBQto2Q_t_channel_4FS
+    - TBbarQtoLNu_t_channel_4FS
+    - TBbarQto2Q_t_channel_4FS
+    - TbarWplusto2L2Nu
+    - TbarWplusto4Q
+    - TbarWplustoLNu2Q
+    - TWminusto2L2Nu
+    - TWminusto4Q
+    - TWminustoLNu2Q
 
 ttH:
   name: "ttH"
@@ -82,7 +94,20 @@ ttH:
 WtoLNu:
   name: "W+jets"
   color: "kOrange"
-  datasets: [ ]
+  datasets:
+    - WtoENu_amcatnloFXFX
+    - WtoMuNu_amcatnloFXFX
+    - WtoTauNu_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 VV:
   name: "VV"
@@ -111,17 +136,35 @@ VVV:
 VBFH:
   name: "VBF H"
   color: "kCyan-7"
-  datasets: [ ]
+  datasets:
+    - VBFHto2B_M125
+    - VBFHto2Tau_UncorrelatedDecay_UnFiltered
+    - VBFHto2Wto2L2Nu_M125
 
 ggH:
   name: "ggH"
   color: "kMagenta-7"
-  datasets: [ ]
+  datasets:
+    - GluGluHto2Tau_M125
+    - GluGluHto2Tau_UncorrelatedDecay_UnFiltered
+    - GluGluHto2B_M125
+    - GluGluHto2Wto2L2Nu_M125
 
 VH:
   name: "VH"
   color: "kMagenta-3"
-  datasets: [ ]
+  datasets:
+    - ggZH_Hto2B_Zto2L
+    - ggZH_Hto2B_Zto2Q
+    - WminusH_Hto2B_WtoLNu
+    - WminusH_Hto2B_Wto2Q
+    - WminusHto2Tau_UncorrelatedDecay_UnFiltered
+    - WplusH_Hto2B_WtoLNu
+    - WplusH_Hto2B_Wto2Q
+    - WplusHto2Tau_UncorrelatedDecay_UnFiltered
+    - ZHto2Tau_UncorrelatedDecay_UnFiltered
+    - ZH_Hto2B_Zto2L
+    - ZH_Hto2B_Zto2Q
 
 GluGlutoHHto2B2Tau:
   name: "GluGlutoHHto2B2Tau"
@@ -134,7 +177,7 @@ GluGlutoHHto2B2Tau:
     name_pattern: GluGluToHHto2B2Tau kl ${kl} kt ${kt} c2 ${c2}
     to_plot:
       - [ '0p00', '1p00', '0p00' ]
-      - [ '1p00', '1p00', '0p00' ]  # This is the sample the robot tests
+      - [ '1p00', '1p00', '0p00' ]
     plot_color: [ "kBlack", "kRed" ]
   datasets:
     - GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_0p00
@@ -173,10 +216,76 @@ VBFHHto2B2Tau:
 
 Data:
   name: "Data"
-  datasets: [ ]
+  datasets:
+    - EGamma0_Run2024C
+    - EGamma0_Run2024D
+    - EGamma0_Run2024E
+    - EGamma0_Run2024F
+    - EGamma0_Run2024G
+    - EGamma0_Run2024H
+    - EGamma0_Run2024I_v1
+    - EGamma0_Run2024I_v2
+    - EGamma1_Run2024C
+    - EGamma1_Run2024D
+    - EGamma1_Run2024E
+    - EGamma1_Run2024F
+    - EGamma1_Run2024G
+    - EGamma1_Run2024H
+    - EGamma1_Run2024I_v1
+    - EGamma1_Run2024I_v2
+    - Muon0_Run2024C
+    - Muon0_Run2024D
+    - Muon0_Run2024E
+    - Muon0_Run2024F
+    - Muon0_Run2024G
+    - Muon0_Run2024H
+    - Muon0_Run2024I_v1
+    - Muon0_Run2024I_v2
+    - Muon1_Run2024C
+    - Muon1_Run2024D
+    - Muon1_Run2024E
+    - Muon1_Run2024F
+    - Muon1_Run2024G
+    - Muon1_Run2024H
+    - Muon1_Run2024I_v1
+    - Muon1_Run2024I_v2
+    - MuonEG_Run2024C
+    - MuonEG_Run2024D
+    - MuonEG_Run2024E
+    - MuonEG_Run2024F
+    - MuonEG_Run2024G
+    - MuonEG_Run2024H
+    - MuonEG_Run2024I_v1
+    - MuonEG_Run2024I_v2
+    - Tau_Run2024C
+    - Tau_Run2024D
+    - Tau_Run2024E
+    - Tau_Run2024F
+    - Tau_Run2024G
+    - Tau_Run2024H
+    - Tau_Run2024I_v1
+    - Tau_Run2024I_v2
 
 custom_CI:
   name: "custom for CI and test purposes"
   color: "kAzure+10"
   datasets:
     - custom_CI
+
+custom_CI_Background:
+  name: "CI -- Background"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+
+custom_CI_Signal:
+  name: "CI -- Signal"
+  color: "kAzure+10"
+  datasets:
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00
+
+custom_CI_Data:
+  name: "CI -- Data"
+  color: "kAzure+10"
+  datasets:
+    - Muon0_Run2024C

--- a/config/Run3_2024/processes.yaml
+++ b/config/Run3_2024/processes.yaml
@@ -98,16 +98,6 @@ WtoLNu:
     - WtoENu_amcatnloFXFX
     - WtoMuNu_amcatnloFXFX
     - WtoTauNu_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 VV:
   name: "VV"

--- a/config/Run3_2025/datasets.yaml
+++ b/config/Run3_2025/datasets.yaml
@@ -1,0 +1,8 @@
+# 2025 official MC is reused from Run3_2024 (reuse_mc_from_era).
+custom_CI:
+  generator: powheg
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+  fs_nanoAOD: T3_CH_CERNBOX:/store/user/vdamante/
+  dirName: "nanobbtt_2024"

--- a/config/Run3_2025/global.yaml
+++ b/config/Run3_2025/global.yaml
@@ -1,0 +1,46 @@
+triggerFile: config/Run3_2025/triggers.yaml
+corrections:
+  lumi: { stage: AnaTuple }
+  xs: { stage: AnaTuple }
+  gen: { stage: AnaTuple }
+  pu:
+    stages: [ AnaTuple, AnaTupleMerge ]
+    enabled:
+      AnaTuple: true
+      AnaTupleMerge: false
+  base: { stage: AnaTupleMerge }
+  tauID: { stage: HistTuple }
+  tauES: { stage: AnaTuple }
+  mu:
+    stage: HistTuple
+    columns:
+      pfRelIso04_all: Muon_pfRelIso04_all
+      tightId: Muon_tightId
+      tkRelIso: Muon_tkRelIso
+      highPtId: Muon_highPtId
+      mediumId: Muon_mediumId
+      looseId: Muon_looseId
+  trigger:
+    stage: HistTuple
+    mode: efficiency
+  ele: { stage: HistTuple }
+  muScaRe: { stage: AnaTuple, mu_pt_for_ScaReApplication: "nano" }
+  eleES: { stage: AnaTuple }
+  JEC: { stage: AnaTuple }
+  JER:
+    stage: AnaTuple
+    apply_jet_horns_fix: true
+  btag:
+    stages: [ AnaTuple ]
+    modes:
+      AnaTuple: none
+    tagger: UParTAK4
+    jetCollection: centralJet
+    wantShape: false
+  dy_hhbbtautau:
+    stages: [ HistTuple ]
+    processes: [ DY_M_10to50, DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]
+  bosonicRecoil:
+    stage: HistTuple
+    method: QuantileMapHist
+    apply_systematics: true

--- a/config/Run3_2025/global.yaml
+++ b/config/Run3_2025/global.yaml
@@ -1,4 +1,8 @@
 triggerFile: config/Run3_2025/triggers.yaml
+nano_version: v15
+nanoAODVersions:
+  data: v15
+  mc: v15
 corrections:
   lumi: { stage: AnaTuple }
   xs: { stage: AnaTuple }

--- a/config/Run3_2025/processes.yaml
+++ b/config/Run3_2025/processes.yaml
@@ -1,0 +1,307 @@
+DY:
+  name: "DY"
+  color: "kAzure-9"
+  sub_processes:
+    - DY_M_10to50
+    - DYto2E_M_50
+    - DYto2Mu_M_50
+    - DYto2Tau_M_50
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DY_M_10to50:
+  name: "DY M10to50"
+  color: "kAzure+10"
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DYto2E_M_50:
+  processors: *DY_processors
+  datasets:
+    - DYto2E_M_50_amcatnloFXFX
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DYto2Mu_M_50:
+  processors: *DY_processors
+  datasets:
+    - DYto2Mu_M_50_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DYto2Tau_M_50:
+  processors: *DY_processors
+  datasets:
+    - DYto2Tau_M_50_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+TT:
+  name: "t#bar{t}"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+    - TTtoLNu2Q
+    - TTto4Q
+
+ST:
+  name: "Single Top"
+  color: "kGreen-5"
+  datasets:
+    - TbarBtoLminusNuB_s_channel_4FS
+    - TBbartoLplusNuBbar_s_channel_4FS
+    - TbarBQtoLNu_t_channel_4FS
+    - TbarBQto2Q_t_channel_4FS
+    - TBbarQtoLNu_t_channel_4FS
+    - TBbarQto2Q_t_channel_4FS
+    - TbarWplusto2L2Nu
+    - TbarWplusto4Q
+    - TbarWplustoLNu2Q
+    - TWminusto2L2Nu
+    - TWminusto4Q
+    - TWminustoLNu2Q
+
+ttH:
+  name: "ttH"
+  color: "kGreen-7"
+  datasets:
+    - TTHtoNon2B_M125
+    - TTHto2B_M125
+
+WtoLNu:
+  name: "W+jets"
+  color: "kOrange"
+  datasets:
+    - WtoENu_amcatnloFXFX
+    - WtoMuNu_amcatnloFXFX
+    - WtoTauNu_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
+    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
+    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
+
+VV:
+  name: "VV"
+  color: "kRed+1"
+  datasets:
+    - WWto2L2Nu_powheg
+    - WWtoLNu2Q_powheg
+    - WWto4Q_powheg
+    - WZto3LNu_powheg
+    - WZto2L2Q_powheg
+    - WZtoLNu2Q_powheg
+    - ZZto4L_powheg
+    - ZZto2L2Nu_powheg
+    - ZZto2L2Q_powheg
+    - ZZto2Nu2Q_powheg
+
+VVV:
+  name: "VVV"
+  color: "kRed+4"
+  datasets:
+    - WWW_4F
+    - WWZ_4F
+    - WZZ
+    - ZZZ
+
+VBFH:
+  name: "VBF H"
+  color: "kCyan-7"
+  datasets:
+    - VBFHto2B_M125
+    - VBFHto2Tau_UncorrelatedDecay_UnFiltered
+    - VBFHto2Wto2L2Nu_M125
+
+ggH:
+  name: "ggH"
+  color: "kMagenta-7"
+  datasets:
+    - GluGluHto2Tau_M125
+    - GluGluHto2Tau_UncorrelatedDecay_UnFiltered
+    - GluGluHto2B_M125
+    - GluGluHto2Wto2L2Nu_M125
+
+VH:
+  name: "VH"
+  color: "kMagenta-3"
+  datasets:
+    - ggZH_Hto2B_Zto2L
+    - ggZH_Hto2B_Zto2Q
+    - WminusH_Hto2B_WtoLNu
+    - WminusH_Hto2B_Wto2Q
+    - WminusHto2Tau_UncorrelatedDecay_UnFiltered
+    - WplusH_Hto2B_WtoLNu
+    - WplusH_Hto2B_Wto2Q
+    - WplusHto2Tau_UncorrelatedDecay_UnFiltered
+    - ZHto2Tau_UncorrelatedDecay_UnFiltered
+    - ZH_Hto2B_Zto2L
+    - ZH_Hto2B_Zto2Q
+
+GluGlutoHHto2B2Tau:
+  name: "GluGlutoHHto2B2Tau"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2Tau_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGluToHHto2B2Tau_${kl}_${kt}_${c2}
+    name_pattern: GluGluToHHto2B2Tau kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '0p00', '1p00', '0p00' ]
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlack", "kRed" ]
+  datasets:
+    - GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_1p00
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p10
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p35
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_3p00
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_m2p00
+    - GluGlutoHHto2B2Tau_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Tau_kl_5p00_kt_1p00_c2_0p00
+
+VBFHHto2B2Tau:
+  name: "VBFHHto2B2Tau"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2Tau_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)_fixedTauDecays$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2Tau_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2Tau CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '0', '1' ]
+    plot_color: [ "kBlack" ]
+  datasets:
+    - VBFHHto2B2Tau_CV_1_C2V_0_C3_1_fixedTauDecays
+    - VBFHHto2B2Tau_CV_1_C2V_1_C3_1_fixedTauDecays
+    - VBFHHto2B2Tau_CV_1p74_C2V_1p37_C3_14p4_fixedTauDecays
+    - VBFHHto2B2Tau_CV_2p12_C2V_3p87_C3_m5p96_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m0p012_C2V_0p030_C3_10p2_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m0p758_C2V_1p44_C3_m19p3_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m0p962_C2V_0p959_C3_m1p43_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m1p21_C2V_1p94_C3_m0p94_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m1p60_C2V_2p72_C3_m1p36_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m1p83_C2V_3p57_C3_m3p39_fixedTauDecays
+
+Data:
+  name: "Data"
+  datasets:
+    - EGamma0_Run2025B_v1
+    - EGamma0_Run2025C_v1
+    - EGamma0_Run2025C_v2
+    - EGamma0_Run2025D_v1
+    - EGamma0_Run2025E_v1
+    - EGamma0_Run2025F_v1
+    - EGamma0_Run2025F_v2
+    - EGamma0_Run2025G_v1
+    - EGamma1_Run2025B_v1
+    - EGamma1_Run2025C_v1
+    - EGamma1_Run2025C_v2
+    - EGamma1_Run2025D_v1
+    - EGamma1_Run2025E_v1
+    - EGamma1_Run2025F_v1
+    - EGamma1_Run2025F_v2
+    - EGamma1_Run2025G_v1
+    - EGamma2_Run2025B_v1
+    - EGamma2_Run2025C_v1
+    - EGamma2_Run2025C_v2
+    - EGamma2_Run2025D_v1
+    - EGamma2_Run2025E_v1
+    - EGamma2_Run2025F_v1
+    - EGamma2_Run2025F_v2
+    - EGamma2_Run2025G_v1
+    - EGamma3_Run2025B_v1
+    - EGamma3_Run2025C_v1
+    - EGamma3_Run2025C_v2
+    - EGamma3_Run2025D_v1
+    - EGamma3_Run2025E_v1
+    - EGamma3_Run2025F_v1
+    - EGamma3_Run2025F_v2
+    - EGamma3_Run2025G_v1
+    - Muon0_Run2025B_v1
+    - Muon0_Run2025C_v1
+    - Muon0_Run2025C_v2
+    - Muon0_Run2025D_v1
+    - Muon0_Run2025E_v1
+    - Muon0_Run2025F_v1
+    - Muon0_Run2025F_v2
+    - Muon0_Run2025G_v1
+    - Muon1_Run2025B_v1
+    - Muon1_Run2025C_v1
+    - Muon1_Run2025C_v2
+    - Muon1_Run2025D_v1
+    - Muon1_Run2025E_v1
+    - Muon1_Run2025F_v1
+    - Muon1_Run2025F_v2
+    - Muon1_Run2025G_v1
+    - MuonEG_Run2025B_v1
+    - MuonEG_Run2025C_v1
+    - MuonEG_Run2025C_v2
+    - MuonEG_Run2025D_v1
+    - MuonEG_Run2025E_v1
+    - MuonEG_Run2025F_v1
+    - MuonEG_Run2025F_v2
+    - MuonEG_Run2025G_v1
+    - Tau_Run2025B_v1
+    - Tau_Run2025C_v1
+    - Tau_Run2025C_v2
+    - Tau_Run2025D_v1
+    - Tau_Run2025E_v1
+    - Tau_Run2025F_v1
+    - Tau_Run2025F_v2
+    - Tau_Run2025G_v1
+
+custom_CI:
+  name: "custom for CI and test purposes"
+  color: "kAzure+10"
+  datasets:
+    - custom_CI
+
+custom_CI_Background:
+  name: "CI -- Background"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+
+custom_CI_Signal:
+  name: "CI -- Signal"
+  color: "kAzure+10"
+  datasets:
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00
+
+custom_CI_Data:
+  name: "CI -- Data"
+  color: "kAzure+10"
+  datasets:
+    - Muon0_Run2025B_v1

--- a/config/Run3_2025/processes.yaml
+++ b/config/Run3_2025/processes.yaml
@@ -98,16 +98,6 @@ WtoLNu:
     - WtoENu_amcatnloFXFX
     - WtoMuNu_amcatnloFXFX
     - WtoTauNu_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_1J_amcatnloFXFX
-    - WtoLNu_PTLNu_40to100_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_100to200_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_200to400_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_400to600_2J_amcatnloFXFX
-    - WtoLNu_PTLNu_600_2J_amcatnloFXFX
 
 VV:
   name: "VV"

--- a/config/Run3_2025/triggers.yaml
+++ b/config/Run3_2025/triggers.yaml
@@ -1,0 +1,168 @@
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauTrigger#Updates_for_2022_data_taking
+
+vbf:  # to check kinematic cuts for offline objs and trigger bits for online objs
+  channels:
+    - tauTau
+  path:
+    - HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 25 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&1024)!=0
+      dRMatching: 0.4
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': '', '2022_Summer22EE': '', "2023_Summer23": '', "2023_Summer23BPix": '', "2024_Summer24": '', "2025_Summer24": '' }
+      jsonTRGcorrection_elepath: "placeholder"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::jet && {obj}_pt > 60"
+      online_obj:
+        cut: TrigObj_id==1 && (TrigObj_filterBits&262144)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'jetlegSFs', '2022_Summer22EE': 'jetlegSFs', "2023_Summer23": '', "2023_Summer23BPix": '', "2024_Summer24": '', "2025_Summer24": '' }
+      jsonTRGcorrection_elepath: "placeholder"
+
+ditau:
+  channels:
+    - tauTau
+  path:
+    - HLT_DoubleMediumDeepTauPFTauHPS35_L2NN_eta2p1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 40 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&2048)!=0
+      dRMatching: 0.4
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'tau_trigger', '2022_Summer22EE': 'tau_trigger', "2023_Summer23": 'tau_trigger', "2023_Summer23BPix": 'tau_trigger', "2024_Summer24": 'tau_trigger', "2025_Summer24": 'tau_trigger' }
+      jsonTRGcorrection_elepath: "placeholder"
+ditaujet:
+  channels:
+    - tauTau
+  path:
+    - HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 35 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&2048)!=0 && (TrigObj_filterBits&16384)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'tau_trigger', '2022_Summer22EE': 'tau_trigger', "2023_Summer23": 'tau_trigger', "2023_Summer23BPix": 'tau_trigger', "2024_Summer24": 'tau_trigger', "2025_Summer24": 'tau_trigger' }
+      jsonTRGcorrection_elepath: "placeholder"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::jet && {obj}_pt > 60"
+      online_obj:
+        cut: TrigObj_id==1 && (TrigObj_filterBits&131072)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'jetlegSFs', '2022_Summer22EE': 'jetlegSFs', "2023_Summer23": 'jetlegSFs', "2023_Summer23BPix": 'jetlegSFs', "2024_Summer24": 'jetlegSFs', "2025_Summer24": 'jetlegSFs' }
+      jsonTRGcorrection_elepath: "placeholder"
+
+mutau:
+  channels:
+    - muTau
+  path:
+    - HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 22 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==13 && (TrigObj_filterBits&64)!=0  # && TrigObj_pt>20
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2022_Summer22EE": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2023_Summer23": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2023_Summer23BPix": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2024_Summer24": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2025_Summer24": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff" }
+      jsonTRGcorrection_elepath: "placeholder"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 32 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&8192)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "tau_trigger", "2022_Summer22EE": "tau_trigger", "2023_Summer23": "tau_trigger", "2023_Summer23BPix": "tau_trigger", "2024_Summer24": "tau_trigger", "2025_Summer24": "tau_trigger" }
+      jsonTRGcorrection_elepath: "placeholder"
+
+etau:
+  channels:
+    - eTau
+  path:
+    - HLT_Ele24_eta2p1_WPTight_Gsf_LooseDeepTauPFTauHPS30_eta2p1_CrossL1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 26 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&128)!=0  # && TrigObj_pt>24
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "Electron-HLT-{}Eff", "2022_Summer22EE": "Electron-HLT-{}Eff", "2023_Summer23": "Electron-HLT-{}Eff", "2023_Summer23BPix": "Electron-HLT-{}Eff", "2024_Summer24": "Electron-HLT-{}Eff", "2025_Summer24": "Electron-HLT-{}Eff" }
+      jsonTRGcorrection_elepath: "HLT_SF_Ele24_TightID"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 35 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&4096)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "tau_trigger", "2022_Summer22EE": "tau_trigger", "2023_Summer23": "tau_trigger", "2023_Summer23BPix": "tau_trigger", "2024_Summer24": "tau_trigger", "2025_Summer24": "tau_trigger" }
+      jsonTRGcorrection_elepath: "placeholder"
+
+singleMu:
+  channels:
+    - muMu
+    - eMu
+    - mu
+  path:
+    - HLT_IsoMu24
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 26" # {obj}_pt > 26 && abs({obj}_eta) < 2.4
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&8)!=0
+      doMatching: True
+      jsonTRGcorrection_key:
+        2022_Summer22: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2022_Summer22EE: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2023_Summer23: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2023_Summer23BPix: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2024_Summer24: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+      jsonTRGcorrection_elepath: "placeholder"
+
+singleEle:
+  channels:
+    - eMu
+    - eE
+    - e
+  path:
+    - HLT_Ele30_WPTight_Gsf
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 32"  # {obj}_pt > 32 && abs({obj}_eta) < 2.4
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&2)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "Electron-HLT-{}Eff", "2022_Summer22EE": "Electron-HLT-{}Eff", "2023_Summer23": "Electron-HLT-{}Eff", "2023_Summer23BPix": "Electron-HLT-{}Eff", "2024_Summer24": "Electron-HLT-{}Eff", "2025_Summer24": "Electron-HLT-{}Eff" }
+      jsonTRGcorrection_elepath: "HLT_SF_Ele30_TightID"
+
+# MET:
+#     channels:
+#       - tauTau
+#       - muTau
+#       - eTau
+#       - eMu
+#       - muMu
+#       - eE
+#     path:
+#       - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
+#     legs:
+#       - offline_obj:
+#           type: MET
+#           cut: metnomu_pt > 150
+#         doMatching: False
+
+# singleTau:
+#     channels:
+#       - tauTau
+#       - muTau
+#       - eTau
+#     path:
+#       - HLT_LooseDeepTauPFTauHPS180_L2NN_eta2p1
+#     legs:
+#       - offline_obj:
+#           type: Tau
+#           cut: v_ops::pt(Tau_p4) > 190 && abs(v_ops::eta(Tau_p4)) < 2.1
+#         online_obj:
+#           cut: TrigObj_id == 15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&512)!=0
+#         doMatching: True

--- a/config/Run3_2025/triggers.yaml
+++ b/config/Run3_2025/triggers.yaml
@@ -118,6 +118,7 @@ singleMu:
         2023_Summer23: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
         2023_Summer23BPix: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
         2024_Summer24: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2025_Summer24: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
       jsonTRGcorrection_elepath: "placeholder"
 
 singleEle:

--- a/config/Run3_2025/weights.yaml
+++ b/config/Run3_2025/weights.yaml
@@ -1,0 +1,88 @@
+norm:
+  PileUp_Lumi_MC:
+    expression: weight_base_pu{scale}_rel  * final_weight
+    name: CMS_pileup_{}
+  MuonID_SF_Iso_ID:
+    expression: weight_tau1_MuonID_SF_{muIso_WP_for_SF}PFIso_{muID_WP_for_SF}ID{scale}_rel * weight_tau2_MuonID_SF_{muIso_WP_for_SF}PFIso_{muID_WP_for_SF}ID{scale}_rel * final_weight
+    name: CMS_eff_m_id_iso_{}
+  MuonID_SF_ID:
+    expression: weight_tau1_MuonID_SF_{muID_WP_for_SF}ID_Trk{scale}_rel * weight_tau2_MuonID_SF_{muID_WP_for_SF}ID_Trk{scale}_rel * final_weight
+    name: CMS_eff_m_id_{}
+  # MuonID_TightID:
+  #   expression: weight_tau1_MuonID_SF_TightID_Trk{scale}_rel * weight_tau2_MuonID_SF_TightID_Trk{scale}_rel * final_weight
+  #   name: MuonID_TightID
+  # MuonID_TightIDIso:
+  #   expression: weight_tau1_MuonID_SF_LoosePFIso{scale}_rel * weight_tau2_MuonID_SF_LoosePFIso{scale}_rel * final_weight
+  #   name: MuonID_TightIDIso
+  trg_eTau_e:
+    expression: weight_trgSF_eTau_eleg_{scale}_rel * final_weight
+    name: trg_eTau_e_{}
+  trg_eTau_tau_dm0:
+    expression: weight_trgSF_eTau_tauleg_dm0_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm0_{}
+  trg_eTau_tau_dm1:
+    expression: weight_trgSF_eTau_tauleg_dm1_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm1_{}
+  trg_eTau_tau_dm10:
+    expression: weight_trgSF_eTau_tauleg_dm10_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm10_{}
+  trg_eTau_tau_dm11:
+    expression: weight_trgSF_eTau_tauleg_dm11_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm11_{}
+  trg_muTau_mu:
+    expression: weight_trgSF_muTau_muleg_{scale}_rel * final_weight
+    name: trg_muTau_mu_{}
+  trg_muTau_tau_dm0:
+    expression: weight_trgSF_muTau_tauleg_dm0_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm0_{}
+  trg_muTau_tau_dm1:
+    expression: weight_trgSF_muTau_tauleg_dm1_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm1_{}
+  trg_muTau_tau_dm10:
+    expression: weight_trgSF_muTau_tauleg_dm10_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm10_{}
+  trg_muTau_tau_dm11:
+    expression: weight_trgSF_muTau_tauleg_dm11_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm11_{}
+  trg_tauTau_tau_dm0:
+    expression: weight_trgSF_tauTau_tau1leg_dm0_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm0_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm0_{}
+  trg_tauTau_tau_dm1:
+    expression: weight_trgSF_tauTau_tau1leg_dm1_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm1_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm1_{}
+  trg_tauTau_tau_dm10:
+    expression: weight_trgSF_tauTau_tau1leg_dm10_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm10_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm10_{}
+  trg_tauTau_tau_dm11:
+    expression: weight_trgSF_tauTau_tau1leg_dm11_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm11_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm11_{}
+  trg_tauTau_jet:
+    expression: weight_trgSF_tauTau_jetleg_{scale}_rel * final_weight
+    name: trg_tauTau_jet_{}
+  trg_muMueMu:
+    expression: weight_trgSF_muMueMu_{scale}_rel * final_weight
+    name: trg_muMueMu_{}
+  trg_eE:
+    expression: weight_trgSF_eE_{scale}_rel * final_weight
+    name: trg_eE_{}
+  DY_stat_btag0:
+    expression: weight_dy_stat_btag0_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_stat_btag0_{}
+  DY_stat_btag1:
+    expression: weight_dy_stat_btag1_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_stat_btag1_{}
+  DY_stat_btag2:
+    expression: weight_dy_stat_btag2_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_stat_btag2_{}
+  DY_syst_gauss:
+    expression: weight_dy_syst_gauss_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_syst_gauss_{}
+  DY_syst_linear:
+    expression: weight_dy_syst_linear_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_syst_linear_{}
+
+shape: # syst unc conventions here: https://gitlab.cern.ch/cms-analysis/general/systematics
+  JES_Total:
+    name: CMS_scale_j_{}
+  JER:
+    name: CMS_res_j_{}

--- a/config/Run3_2026/datasets.yaml
+++ b/config/Run3_2026/datasets.yaml
@@ -1,0 +1,8 @@
+# 2026 official MC is reused from Run3_2024 (reuse_mc_from_era).
+custom_CI:
+  generator: powheg
+  mass: 125
+  spin: 0
+  crossSection: 1pb
+  fs_nanoAOD: T3_CH_CERNBOX:/store/user/vdamante/
+  dirName: "nanobbtt_2024"

--- a/config/Run3_2026/global.yaml
+++ b/config/Run3_2026/global.yaml
@@ -1,0 +1,50 @@
+triggerFile: config/Run3_2026/triggers.yaml
+nano_version: v15
+nanoAODVersions:
+  data: v15
+  mc: v15
+corrections:
+  lumi: { stage: AnaTuple }
+  xs: { stage: AnaTuple }
+  gen: { stage: AnaTuple }
+  pu:
+    stages: [ AnaTuple, AnaTupleMerge ]
+    enabled:
+      AnaTuple: true
+      AnaTupleMerge: false
+  base: { stage: AnaTupleMerge }
+  tauID: { stage: HistTuple }
+  tauES: { stage: AnaTuple }
+  mu:
+    stage: HistTuple
+    columns:
+      pfRelIso04_all: Muon_pfRelIso04_all
+      tightId: Muon_tightId
+      tkRelIso: Muon_tkRelIso
+      highPtId: Muon_highPtId
+      mediumId: Muon_mediumId
+      looseId: Muon_looseId
+  trigger:
+    stage: HistTuple
+    mode: efficiency
+  ele: { stage: HistTuple }
+  muScaRe: { stage: AnaTuple, mu_pt_for_ScaReApplication: "nano" }
+  eleES: { stage: AnaTuple }
+  JEC: { stage: AnaTuple }
+  JER:
+    stage: AnaTuple
+    apply_jet_horns_fix: true
+  btag:
+    stages: [ AnaTuple ]
+    modes:
+      AnaTuple: none
+    tagger: UParTAK4
+    jetCollection: centralJet
+    wantShape: false
+  dy_hhbbtautau:
+    stages: [ HistTuple ]
+    processes: [ DY_M_10to50, DYto2E_M_50, DYto2Mu_M_50, DYto2Tau_M_50 ]
+  bosonicRecoil:
+    stage: HistTuple
+    method: QuantileMapHist
+    apply_systematics: true

--- a/config/Run3_2026/processes.yaml
+++ b/config/Run3_2026/processes.yaml
@@ -206,7 +206,55 @@ VBFHHto2B2Tau:
 
 Data:
   name: "Data"
-  datasets: [ ]  # 2026 data not yet catalogued
+  datasets:
+    - EGamma0_Run2026A_v1
+    - EGamma0_Run2026B_v1
+    - EGamma0_Run2026C_v1
+    - EGamma0_Run2026D_v1
+    - EGamma1_Run2026A_v1
+    - EGamma1_Run2026B_v1
+    - EGamma1_Run2026C_v1
+    - EGamma1_Run2026D_v1
+    - EGamma2_Run2026A_v1
+    - EGamma2_Run2026B_v1
+    - EGamma2_Run2026C_v1
+    - EGamma2_Run2026D_v1
+    - EGamma3_Run2026A_v1
+    - EGamma3_Run2026B_v1
+    - EGamma3_Run2026C_v1
+    - EGamma3_Run2026D_v1
+    - EGamma4_Run2026A_v1
+    - EGamma4_Run2026B_v1
+    - EGamma4_Run2026C_v1
+    - EGamma4_Run2026D_v1
+    - EGamma5_Run2026A_v1
+    - EGamma5_Run2026B_v1
+    - EGamma5_Run2026C_v1
+    - EGamma5_Run2026D_v1
+    - Muon0_Run2026A_v1
+    - Muon0_Run2026B_v1
+    - Muon0_Run2026C_v1
+    - Muon0_Run2026D_v1
+    - Muon1_Run2026A_v1
+    - Muon1_Run2026B_v1
+    - Muon1_Run2026C_v1
+    - Muon1_Run2026D_v1
+    - Muon2_Run2026A_v1
+    - Muon2_Run2026B_v1
+    - Muon2_Run2026C_v1
+    - Muon2_Run2026D_v1
+    - Muon3_Run2026A_v1
+    - Muon3_Run2026B_v1
+    - Muon3_Run2026C_v1
+    - Muon3_Run2026D_v1
+    - MuonEG_Run2026A_v1
+    - MuonEG_Run2026B_v1
+    - MuonEG_Run2026C_v1
+    - MuonEG_Run2026D_v1
+    - Tau_Run2026A_v1
+    - Tau_Run2026B_v1
+    - Tau_Run2026C_v1
+    - Tau_Run2026D_v1
 
 custom_CI:
   name: "custom for CI and test purposes"
@@ -229,4 +277,5 @@ custom_CI_Signal:
 custom_CI_Data:
   name: "CI -- Data"
   color: "kAzure+10"
-  datasets: [ ]  # 2026 data not yet catalogued
+  datasets:
+    - Muon0_Run2026A_v1

--- a/config/Run3_2026/processes.yaml
+++ b/config/Run3_2026/processes.yaml
@@ -1,0 +1,232 @@
+DY:
+  name: "DY"
+  color: "kAzure-9"
+  sub_processes:
+    - DY_M_10to50
+    - DYto2E_M_50
+    - DYto2Mu_M_50
+    - DYto2Tau_M_50
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DY_M_10to50:
+  name: "DY M10to50"
+  color: "kAzure+10"
+  datasets:
+    - DYto2E_M_10to50_amcatnloFXFX
+    - DYto2Mu_M_10to50_amcatnloFXFX
+    - DYto2Tau_M_10to50_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DYto2E_M_50:
+  processors: *DY_processors
+  datasets:
+    - DYto2E_M_50_amcatnloFXFX
+    - DYto2E_M_50_0J_amcatnloFXFX
+    - DYto2E_M_50_1J_amcatnloFXFX
+    - DYto2E_M_50_2J_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DYto2Mu_M_50:
+  processors: *DY_processors
+  datasets:
+    - DYto2Mu_M_50_amcatnloFXFX
+    - DYto2Mu_M_50_0J_amcatnloFXFX
+    - DYto2Mu_M_50_1J_amcatnloFXFX
+    - DYto2Mu_M_50_2J_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+DYto2Tau_M_50:
+  processors: *DY_processors
+  datasets:
+    - DYto2Tau_M_50_amcatnloFXFX
+    - DYto2Tau_M_50_0J_amcatnloFXFX
+    - DYto2Tau_M_50_1J_amcatnloFXFX
+    - DYto2Tau_M_50_2J_amcatnloFXFX
+  corrections:
+    bosonicRecoil:
+      enabled: true
+      order: NLO
+
+TT:
+  name: "t#bar{t}"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+    - TTtoLNu2Q
+    - TTto4Q
+
+ST:
+  name: "Single Top"
+  color: "kGreen-5"
+  datasets:
+    - TbarBtoLminusNuB_s_channel_4FS
+    - TBbartoLplusNuBbar_s_channel_4FS
+    - TbarBQtoLNu_t_channel_4FS
+    - TbarBQto2Q_t_channel_4FS
+    - TBbarQtoLNu_t_channel_4FS
+    - TBbarQto2Q_t_channel_4FS
+    - TbarWplusto2L2Nu
+    - TbarWplusto4Q
+    - TbarWplustoLNu2Q
+    - TWminusto2L2Nu
+    - TWminusto4Q
+    - TWminustoLNu2Q
+
+ttH:
+  name: "ttH"
+  color: "kGreen-7"
+  datasets:
+    - TTHtoNon2B_M125
+    - TTHto2B_M125
+
+WtoLNu:
+  name: "W+jets"
+  color: "kOrange"
+  datasets:
+    - WtoENu_amcatnloFXFX
+    - WtoMuNu_amcatnloFXFX
+    - WtoTauNu_amcatnloFXFX
+
+VV:
+  name: "VV"
+  color: "kRed+1"
+  datasets:
+    - WWto2L2Nu_powheg
+    - WWtoLNu2Q_powheg
+    - WWto4Q_powheg
+    - WZto3LNu_powheg
+    - WZto2L2Q_powheg
+    - WZtoLNu2Q_powheg
+    - ZZto4L_powheg
+    - ZZto2L2Nu_powheg
+    - ZZto2L2Q_powheg
+    - ZZto2Nu2Q_powheg
+
+VVV:
+  name: "VVV"
+  color: "kRed+4"
+  datasets:
+    - WWW_4F
+    - WWZ_4F
+    - WZZ
+    - ZZZ
+
+VBFH:
+  name: "VBF H"
+  color: "kCyan-7"
+  datasets:
+    - VBFHto2B_M125
+    - VBFHto2Tau_UncorrelatedDecay_UnFiltered
+    - VBFHto2Wto2L2Nu_M125
+
+ggH:
+  name: "ggH"
+  color: "kMagenta-7"
+  datasets:
+    - GluGluHto2Tau_M125
+    - GluGluHto2Tau_UncorrelatedDecay_UnFiltered
+    - GluGluHto2B_M125
+    - GluGluHto2Wto2L2Nu_M125
+
+VH:
+  name: "VH"
+  color: "kMagenta-3"
+  datasets:
+    - ggZH_Hto2B_Zto2L
+    - ggZH_Hto2B_Zto2Q
+    - WminusH_Hto2B_WtoLNu
+    - WminusH_Hto2B_Wto2Q
+    - WminusHto2Tau_UncorrelatedDecay_UnFiltered
+    - WplusH_Hto2B_WtoLNu
+    - WplusH_Hto2B_Wto2Q
+    - WplusHto2Tau_UncorrelatedDecay_UnFiltered
+    - ZHto2Tau_UncorrelatedDecay_UnFiltered
+    - ZH_Hto2B_Zto2L
+    - ZH_Hto2B_Zto2Q
+
+GluGlutoHHto2B2Tau:
+  name: "GluGlutoHHto2B2Tau"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^GluGlutoHHto2B2Tau_kl_([a-zA-Z0-9\-\.]+)_kt_([a-zA-Z0-9\-\.]+)_c2_([a-zA-Z0-9\-\.]+)$
+    parameters: [ kl, kt, c2 ]
+    process_name: GluGluToHHto2B2Tau_${kl}_${kt}_${c2}
+    name_pattern: GluGluToHHto2B2Tau kl ${kl} kt ${kt} c2 ${c2}
+    to_plot:
+      - [ '0p00', '1p00', '0p00' ]
+      - [ '1p00', '1p00', '0p00' ]
+    plot_color: [ "kBlack", "kRed" ]
+  datasets:
+    - GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Tau_kl_0p00_kt_1p00_c2_1p00
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p10
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p35
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_3p00
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_m2p00
+    - GluGlutoHHto2B2Tau_kl_2p45_kt_1p00_c2_0p00
+    - GluGlutoHHto2B2Tau_kl_5p00_kt_1p00_c2_0p00
+
+VBFHHto2B2Tau:
+  name: "VBFHHto2B2Tau"
+  color: "kBlack"
+  is_meta_process: true
+  meta_setup:
+    dataset_name_pattern: ^VBFHHto2B2Tau_CV_([a-zA-Z0-9\-\.]+)_C2V_([a-zA-Z0-9\-\.]+)_C3_([a-zA-Z0-9\-\.]+)_fixedTauDecays$
+    parameters: [ CV, C2V, C3 ]
+    process_name: VBFHHto2B2Tau_${CV}_${C2V}_${C3}
+    name_pattern: VBFHHto2B2Tau CV ${CV} C2V ${C2V} C3 ${C3}
+    to_plot:
+      - [ '1', '0', '1' ]
+    plot_color: [ "kBlack" ]
+  datasets:
+    - VBFHHto2B2Tau_CV_1_C2V_0_C3_1_fixedTauDecays
+    - VBFHHto2B2Tau_CV_1_C2V_1_C3_1_fixedTauDecays
+    - VBFHHto2B2Tau_CV_1p74_C2V_1p37_C3_14p4_fixedTauDecays
+    - VBFHHto2B2Tau_CV_2p12_C2V_3p87_C3_m5p96_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m0p012_C2V_0p030_C3_10p2_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m0p758_C2V_1p44_C3_m19p3_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m0p962_C2V_0p959_C3_m1p43_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m1p21_C2V_1p94_C3_m0p94_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m1p60_C2V_2p72_C3_m1p36_fixedTauDecays
+    - VBFHHto2B2Tau_CV_m1p83_C2V_3p57_C3_m3p39_fixedTauDecays
+
+Data:
+  name: "Data"
+  datasets: [ ]  # 2026 data not yet catalogued
+
+custom_CI:
+  name: "custom for CI and test purposes"
+  color: "kAzure+10"
+  datasets:
+    - custom_CI
+
+custom_CI_Background:
+  name: "CI -- Background"
+  color: "kGreen-3"
+  datasets:
+    - TTto2L2Nu
+
+custom_CI_Signal:
+  name: "CI -- Signal"
+  color: "kAzure+10"
+  datasets:
+    - GluGlutoHHto2B2Tau_kl_1p00_kt_1p00_c2_0p00
+
+custom_CI_Data:
+  name: "CI -- Data"
+  color: "kAzure+10"
+  datasets: [ ]  # 2026 data not yet catalogued

--- a/config/Run3_2026/triggers.yaml
+++ b/config/Run3_2026/triggers.yaml
@@ -1,0 +1,169 @@
+# https://twiki.cern.ch/twiki/bin/viewauth/CMS/TauTrigger#Updates_for_2022_data_taking
+
+vbf:  # to check kinematic cuts for offline objs and trigger bits for online objs
+  channels:
+    - tauTau
+  path:
+    - HLT_VBF_DoubleMediumDeepTauPFTauHPS20_eta2p1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 25 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&1024)!=0
+      dRMatching: 0.4
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': '', '2022_Summer22EE': '', "2023_Summer23": '', "2023_Summer23BPix": '', "2024_Summer24": '', "2025_Summer24": '' }
+      jsonTRGcorrection_elepath: "placeholder"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::jet && {obj}_pt > 60"
+      online_obj:
+        cut: TrigObj_id==1 && (TrigObj_filterBits&262144)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'jetlegSFs', '2022_Summer22EE': 'jetlegSFs', "2023_Summer23": '', "2023_Summer23BPix": '', "2024_Summer24": '', "2025_Summer24": '' }
+      jsonTRGcorrection_elepath: "placeholder"
+
+ditau:
+  channels:
+    - tauTau
+  path:
+    - HLT_DoubleMediumDeepTauPFTauHPS35_L2NN_eta2p1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 40 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&2048)!=0
+      dRMatching: 0.4
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'tau_trigger', '2022_Summer22EE': 'tau_trigger', "2023_Summer23": 'tau_trigger', "2023_Summer23BPix": 'tau_trigger', "2024_Summer24": 'tau_trigger', "2025_Summer24": 'tau_trigger' }
+      jsonTRGcorrection_elepath: "placeholder"
+ditaujet:
+  channels:
+    - tauTau
+  path:
+    - HLT_DoubleMediumDeepTauPFTauHPS30_L2NN_eta2p1_PFJet60
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 35 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&2048)!=0 && (TrigObj_filterBits&16384)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'tau_trigger', '2022_Summer22EE': 'tau_trigger', "2023_Summer23": 'tau_trigger', "2023_Summer23BPix": 'tau_trigger', "2024_Summer24": 'tau_trigger', "2025_Summer24": 'tau_trigger' }
+      jsonTRGcorrection_elepath: "placeholder"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::jet && {obj}_pt > 60"
+      online_obj:
+        cut: TrigObj_id==1 && (TrigObj_filterBits&131072)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { '2022_Summer22': 'jetlegSFs', '2022_Summer22EE': 'jetlegSFs', "2023_Summer23": 'jetlegSFs', "2023_Summer23BPix": 'jetlegSFs', "2024_Summer24": 'jetlegSFs', "2025_Summer24": 'jetlegSFs' }
+      jsonTRGcorrection_elepath: "placeholder"
+
+mutau:
+  channels:
+    - muTau
+  path:
+    - HLT_IsoMu20_eta2p1_LooseDeepTauPFTauHPS27_eta2p1_CrossL1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 22 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==13 && (TrigObj_filterBits&64)!=0  # && TrigObj_pt>20
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2022_Summer22EE": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2023_Summer23": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2023_Summer23BPix": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2024_Summer24": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff", "2025_Summer24": "NUM_IsoMu20_DEN_CutBasedIdTight_and_PFIsoTight_{}eff" }
+      jsonTRGcorrection_elepath: "placeholder"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 32 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&8192)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "tau_trigger", "2022_Summer22EE": "tau_trigger", "2023_Summer23": "tau_trigger", "2023_Summer23BPix": "tau_trigger", "2024_Summer24": "tau_trigger", "2025_Summer24": "tau_trigger" }
+      jsonTRGcorrection_elepath: "placeholder"
+
+etau:
+  channels:
+    - eTau
+  path:
+    - HLT_Ele24_eta2p1_WPTight_Gsf_LooseDeepTauPFTauHPS30_eta2p1_CrossL1
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 26 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&128)!=0  # && TrigObj_pt>24
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "Electron-HLT-{}Eff", "2022_Summer22EE": "Electron-HLT-{}Eff", "2023_Summer23": "Electron-HLT-{}Eff", "2023_Summer23BPix": "Electron-HLT-{}Eff", "2024_Summer24": "Electron-HLT-{}Eff", "2025_Summer24": "Electron-HLT-{}Eff" }
+      jsonTRGcorrection_elepath: "HLT_SF_Ele24_TightID"
+    - offline_obj:
+        cut: "{obj}_legType == Leg::tau && {obj}_pt > 35 && abs({obj}_eta) < 2.1"
+      online_obj:
+        cut: TrigObj_id==15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&4096)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "tau_trigger", "2022_Summer22EE": "tau_trigger", "2023_Summer23": "tau_trigger", "2023_Summer23BPix": "tau_trigger", "2024_Summer24": "tau_trigger", "2025_Summer24": "tau_trigger" }
+      jsonTRGcorrection_elepath: "placeholder"
+
+singleMu:
+  channels:
+    - muMu
+    - eMu
+    - mu
+  path:
+    - HLT_IsoMu24
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::mu && {obj}_pt > 26" # {obj}_pt > 26 && abs({obj}_eta) < 2.4
+      online_obj:
+        cut: TrigObj_id == 13 && (TrigObj_filterBits&8)!=0
+      doMatching: True
+      jsonTRGcorrection_key:
+        2022_Summer22: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2022_Summer22EE: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2023_Summer23: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2023_Summer23BPix: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2024_Summer24: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+        2025_Summer24: NUM_IsoMu24_DEN_CutBasedId{MuIDWP}_and_PFIso{MuIDWP}_{DataMC}eff
+      jsonTRGcorrection_elepath: "placeholder"
+
+singleEle:
+  channels:
+    - eMu
+    - eE
+    - e
+  path:
+    - HLT_Ele30_WPTight_Gsf
+  legs:
+    - offline_obj:
+        cut: "{obj}_legType == Leg::e && {obj}_pt > 32"  # {obj}_pt > 32 && abs({obj}_eta) < 2.4
+      online_obj:
+        cut: TrigObj_id==11 && (TrigObj_filterBits&2)!=0
+      doMatching: True
+      jsonTRGcorrection_key: { "2022_Summer22": "Electron-HLT-{}Eff", "2022_Summer22EE": "Electron-HLT-{}Eff", "2023_Summer23": "Electron-HLT-{}Eff", "2023_Summer23BPix": "Electron-HLT-{}Eff", "2024_Summer24": "Electron-HLT-{}Eff", "2025_Summer24": "Electron-HLT-{}Eff" }
+      jsonTRGcorrection_elepath: "HLT_SF_Ele30_TightID"
+
+# MET:
+#     channels:
+#       - tauTau
+#       - muTau
+#       - eTau
+#       - eMu
+#       - muMu
+#       - eE
+#     path:
+#       - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
+#     legs:
+#       - offline_obj:
+#           type: MET
+#           cut: metnomu_pt > 150
+#         doMatching: False
+
+# singleTau:
+#     channels:
+#       - tauTau
+#       - muTau
+#       - eTau
+#     path:
+#       - HLT_LooseDeepTauPFTauHPS180_L2NN_eta2p1
+#     legs:
+#       - offline_obj:
+#           type: Tau
+#           cut: v_ops::pt(Tau_p4) > 190 && abs(v_ops::eta(Tau_p4)) < 2.1
+#         online_obj:
+#           cut: TrigObj_id == 15 && (TrigObj_filterBits&8)!=0 && (TrigObj_filterBits&512)!=0
+#         doMatching: True

--- a/config/Run3_2026/weights.yaml
+++ b/config/Run3_2026/weights.yaml
@@ -1,0 +1,88 @@
+norm:
+  PileUp_Lumi_MC:
+    expression: weight_base_pu{scale}_rel  * final_weight
+    name: CMS_pileup_{}
+  MuonID_SF_Iso_ID:
+    expression: weight_tau1_MuonID_SF_{muIso_WP_for_SF}PFIso_{muID_WP_for_SF}ID{scale}_rel * weight_tau2_MuonID_SF_{muIso_WP_for_SF}PFIso_{muID_WP_for_SF}ID{scale}_rel * final_weight
+    name: CMS_eff_m_id_iso_{}
+  MuonID_SF_ID:
+    expression: weight_tau1_MuonID_SF_{muID_WP_for_SF}ID_Trk{scale}_rel * weight_tau2_MuonID_SF_{muID_WP_for_SF}ID_Trk{scale}_rel * final_weight
+    name: CMS_eff_m_id_{}
+  # MuonID_TightID:
+  #   expression: weight_tau1_MuonID_SF_TightID_Trk{scale}_rel * weight_tau2_MuonID_SF_TightID_Trk{scale}_rel * final_weight
+  #   name: MuonID_TightID
+  # MuonID_TightIDIso:
+  #   expression: weight_tau1_MuonID_SF_LoosePFIso{scale}_rel * weight_tau2_MuonID_SF_LoosePFIso{scale}_rel * final_weight
+  #   name: MuonID_TightIDIso
+  trg_eTau_e:
+    expression: weight_trgSF_eTau_eleg_{scale}_rel * final_weight
+    name: trg_eTau_e_{}
+  trg_eTau_tau_dm0:
+    expression: weight_trgSF_eTau_tauleg_dm0_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm0_{}
+  trg_eTau_tau_dm1:
+    expression: weight_trgSF_eTau_tauleg_dm1_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm1_{}
+  trg_eTau_tau_dm10:
+    expression: weight_trgSF_eTau_tauleg_dm10_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm10_{}
+  trg_eTau_tau_dm11:
+    expression: weight_trgSF_eTau_tauleg_dm11_{scale}_rel * final_weight
+    name: trg_eTau_tau_dm11_{}
+  trg_muTau_mu:
+    expression: weight_trgSF_muTau_muleg_{scale}_rel * final_weight
+    name: trg_muTau_mu_{}
+  trg_muTau_tau_dm0:
+    expression: weight_trgSF_muTau_tauleg_dm0_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm0_{}
+  trg_muTau_tau_dm1:
+    expression: weight_trgSF_muTau_tauleg_dm1_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm1_{}
+  trg_muTau_tau_dm10:
+    expression: weight_trgSF_muTau_tauleg_dm10_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm10_{}
+  trg_muTau_tau_dm11:
+    expression: weight_trgSF_muTau_tauleg_dm11_{scale}_rel * final_weight
+    name: trg_muTau_tau_dm11_{}
+  trg_tauTau_tau_dm0:
+    expression: weight_trgSF_tauTau_tau1leg_dm0_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm0_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm0_{}
+  trg_tauTau_tau_dm1:
+    expression: weight_trgSF_tauTau_tau1leg_dm1_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm1_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm1_{}
+  trg_tauTau_tau_dm10:
+    expression: weight_trgSF_tauTau_tau1leg_dm10_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm10_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm10_{}
+  trg_tauTau_tau_dm11:
+    expression: weight_trgSF_tauTau_tau1leg_dm11_{scale}_rel * weight_trgSF_tauTau_tau2leg_dm11_{scale}_rel  * final_weight
+    name: trg_tauTau_tau_dm11_{}
+  trg_tauTau_jet:
+    expression: weight_trgSF_tauTau_jetleg_{scale}_rel * final_weight
+    name: trg_tauTau_jet_{}
+  trg_muMueMu:
+    expression: weight_trgSF_muMueMu_{scale}_rel * final_weight
+    name: trg_muMueMu_{}
+  trg_eE:
+    expression: weight_trgSF_eE_{scale}_rel * final_weight
+    name: trg_eE_{}
+  DY_stat_btag0:
+    expression: weight_dy_stat_btag0_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_stat_btag0_{}
+  DY_stat_btag1:
+    expression: weight_dy_stat_btag1_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_stat_btag1_{}
+  DY_stat_btag2:
+    expression: weight_dy_stat_btag2_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_stat_btag2_{}
+  DY_syst_gauss:
+    expression: weight_dy_syst_gauss_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_syst_gauss_{}
+  DY_syst_linear:
+    expression: weight_dy_syst_linear_{scale} / weight_dy_central * final_weight
+    name: CMS_dy_syst_linear_{}
+
+shape: # syst unc conventions here: https://gitlab.cern.ch/cms-analysis/general/systematics
+  JES_Total:
+    name: CMS_scale_j_{}
+  JER:
+    name: CMS_res_j_{}

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -286,6 +286,8 @@ singleMu_th:
   "Run3_2022EE": 26
   "Run3_2023": 26
   "Run3_2023BPix": 26
+  "Run3_2024": 26
+  "Run3_2025": 26
 
 singleEle_th:
   "Run2_2016": 26
@@ -296,6 +298,8 @@ singleEle_th:
   "Run3_2022EE": 32
   "Run3_2023": 32
   "Run3_2023BPix": 32
+  "Run3_2024": 32
+  "Run3_2025": 32
 
 singleTau_th:
   "Run2_2016": 130
@@ -306,6 +310,8 @@ singleTau_th:
   "Run3_2022EE": 190
   "Run3_2023": 190
   "Run3_2023BPix": 190
+  "Run3_2024": 190
+  "Run3_2025": 190
 
 eTau_th:
   "Run2_2016":

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -401,6 +401,8 @@ uncs_to_exclude:
   Run3_2022EE: [ ]
   Run3_2023: [ ]
   Run3_2023BPix: [ ]
+  Run3_2024: [ ]
+  Run3_2025: [ ]
   Run2_2018:
     - JES_BBEC1_2017
     - JES_Absolute_2017

--- a/config/global.yaml
+++ b/config/global.yaml
@@ -288,6 +288,7 @@ singleMu_th:
   "Run3_2023BPix": 26
   "Run3_2024": 26
   "Run3_2025": 26
+  "Run3_2026": 26
 
 singleEle_th:
   "Run2_2016": 26
@@ -300,6 +301,7 @@ singleEle_th:
   "Run3_2023BPix": 32
   "Run3_2024": 32
   "Run3_2025": 32
+  "Run3_2026": 32
 
 singleTau_th:
   "Run2_2016": 130
@@ -312,6 +314,7 @@ singleTau_th:
   "Run3_2023BPix": 190
   "Run3_2024": 190
   "Run3_2025": 190
+  "Run3_2026": 190
 
 eTau_th:
   "Run2_2016":
@@ -403,6 +406,7 @@ uncs_to_exclude:
   Run3_2023BPix: [ ]
   Run3_2024: [ ]
   Run3_2025: [ ]
+  Run3_2026: [ ]
   Run2_2018:
     - JES_BBEC1_2017
     - JES_Absolute_2017

--- a/config/plot/Run3_2024.yaml
+++ b/config/plot/Run3_2024.yaml
@@ -1,0 +1,21 @@
+lumi_text:
+  text: "109.9 fb^{-1} (13.6 TeV)"
+  pos_ref: inner_right_top
+  pos: [ 0., -0.035 ]
+  text_size: 0.035
+  font: 42
+  align: right_bottom
+
+channel_text:
+  'eTau': 'bb#tau_{e}#tau_{h}'
+  'muTau': 'bb#tau_{#mu}#tau_{h}'
+  'tauTau': 'bb#tau_{h}#tau_{h}'
+  'muMu': 'bb#tau_{#mu}#tau_{#mu}'
+  'eMu': 'bb#tau_{e}#tau_{#mu}'
+  'eE': 'bb#tau_{e}#tau_{e}'
+
+customregion_text:
+  'OS_Iso': 'OS, Isolated'
+  'SS_Iso': 'SS, Isolated'
+  'OS_AntiIso': 'OS, Non-Isolated'
+  'SS_AntiIso': 'SS, Non-Isolated'

--- a/config/plot/Run3_2025.yaml
+++ b/config/plot/Run3_2025.yaml
@@ -1,0 +1,21 @@
+lumi_text:
+  text: "110.7 fb^{-1} (13.6 TeV)"
+  pos_ref: inner_right_top
+  pos: [ 0., -0.035 ]
+  text_size: 0.035
+  font: 42
+  align: right_bottom
+
+channel_text:
+  'eTau': 'bb#tau_{e}#tau_{h}'
+  'muTau': 'bb#tau_{#mu}#tau_{h}'
+  'tauTau': 'bb#tau_{h}#tau_{h}'
+  'muMu': 'bb#tau_{#mu}#tau_{#mu}'
+  'eMu': 'bb#tau_{e}#tau_{#mu}'
+  'eE': 'bb#tau_{e}#tau_{e}'
+
+customregion_text:
+  'OS_Iso': 'OS, Isolated'
+  'SS_Iso': 'SS, Isolated'
+  'OS_AntiIso': 'OS, Non-Isolated'
+  'SS_AntiIso': 'SS, Non-Isolated'

--- a/config/plot/Run3_2026.yaml
+++ b/config/plot/Run3_2026.yaml
@@ -1,0 +1,21 @@
+lumi_text:
+  text: "25.8 fb^{-1} (13.6 TeV)"
+  pos_ref: inner_right_top
+  pos: [ 0., -0.035 ]
+  text_size: 0.035
+  font: 42
+  align: right_bottom
+
+channel_text:
+  'eTau': 'bb#tau_{e}#tau_{h}'
+  'muTau': 'bb#tau_{#mu}#tau_{h}'
+  'tauTau': 'bb#tau_{h}#tau_{h}'
+  'muMu': 'bb#tau_{#mu}#tau_{#mu}'
+  'eMu': 'bb#tau_{e}#tau_{#mu}'
+  'eE': 'bb#tau_{e}#tau_{e}'
+
+customregion_text:
+  'OS_Iso': 'OS, Isolated'
+  'SS_Iso': 'SS, Isolated'
+  'OS_AntiIso': 'OS, Non-Isolated'
+  'SS_AntiIso': 'SS, Non-Isolated'

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,5 +54,6 @@ New to FLAF? Read [Key terms](https://cms-flaf.github.io/FLAF/getting-started/ke
 
 ## Eras
 
-HH→bb̄ττ currently runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023` and
-`Run3_2023BPix`. See [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).
+HH→bb̄ττ currently runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023`,
+`Run3_2023BPix`, `Run3_2024` and `Run3_2025`. 2025 reuses the 2024 Summer24 MC (with
+2025 corrections); see [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,5 +55,6 @@ New to FLAF? Read [Key terms](https://cms-flaf.github.io/FLAF/getting-started/ke
 ## Eras
 
 HH→bb̄ττ currently runs over the Run 3 eras `Run3_2022`, `Run3_2022EE`, `Run3_2023`,
-`Run3_2023BPix`, `Run3_2024` and `Run3_2025`. 2025 reuses the 2024 Summer24 MC (with
-2025 corrections); see [FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).
+`Run3_2023BPix`, `Run3_2024`, `Run3_2025` and `Run3_2026`. 2025 and 2026 reuse the
+2024 Summer24 MC (with that year's corrections); see
+[FLAF → Eras](https://cms-flaf.github.io/FLAF/concepts/eras/).


### PR DESCRIPTION
## Summary

HH_bbtautau configs and producers for `Run3_2024` / `Run3_2025` (NanoAODv15).

- Era configs: datasets, processes, triggers, weights, plot
- Official samples use `nanoAODVersions` v15
- Skip missing NanoAOD jet/fatjet/subjet columns (no `Jet_puId_*`, `idbtagPNetB`, …)
- 2024/2025 b-tag WPs (UParTAK4 L/M/T) and single-lepton trigger thresholds
- `nBJets` falls back to UParTAK4/PNet scores when `idbtagPNetB` is absent
- Empty `uncs_to_exclude` for 2024/2025; 2025 `singleMu` trigger SF key
- FLAF + Corrections gitlinks for the matching `prepare-run3-2025` PRs
- Docs: `docs/index.md`

Depends on the FLAF and Corrections PRs on the same branch name.

## Testing

Local `--test 1000` TestModel chain through `HistPlotTask` succeeded for `Run3_2024` and `Run3_2025`.